### PR TITLE
Added callback redirection support for public authenticator

### DIFF
--- a/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
@@ -48,9 +48,9 @@ namespace Xero.Api.Example.Applications.Partner
             return string.Empty;
         }
 
-        protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier)
+        protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier, string callback)
         {
-            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier);
+            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier, callback);
         }
     }
 }

--- a/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth.Signing;
+using Xero.Api.Infrastructure.ThirdParty.Dust;
 
 namespace Xero.Api.Example.Applications.Public
 {
@@ -27,9 +28,9 @@ namespace Xero.Api.Example.Applications.Public
             return string.Empty;
         }
 
-        protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier)
+        protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier, string callback)
         {
-            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier);
-        }        
+            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier, callback);
+        }
     }   
 }

--- a/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
+++ b/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
@@ -22,7 +22,7 @@ namespace Xero.Api.Example.Applications
 
         public string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1)
         {
-            return GetAuthorization(GetToken(consumer, user), verb, uri.AbsolutePath, uri.Query);
+            return GetAuthorization(GetToken(consumer, user), verb, uri.AbsolutePath, uri.Query, null, CallBackUri);
         }
 
         public IToken GetToken(IConsumer consumer, IUser user)
@@ -59,7 +59,7 @@ namespace Xero.Api.Example.Applications
         public IUser User { get; set; }
 
         protected abstract string AuthorizeUser(IToken oauthToken);
-        protected abstract string CreateSignature(IToken token, string verb, Uri uri, string verifier);
+        protected abstract string CreateSignature(IToken token, string verb, Uri uri, string verifier, string callback);
 
         private IToken GetToken(IConsumer consumer)
         {
@@ -67,15 +67,15 @@ namespace Xero.Api.Example.Applications
             {
                 ConsumerKey = consumer.ConsumerKey,
                 ConsumerSecret = consumer.ConsumerSecret
-            }, "POST", Tokens.RequestUri));
+            }, "POST", Tokens.RequestUri, null, null, CallBackUri));
 
             var verifier = AuthorizeUser(oauthToken);
 
             return Tokens.GetAccessToken(oauthToken,
-                GetAuthorization(oauthToken, "POST", Tokens.AccessUri, null, verifier));
+                GetAuthorization(oauthToken, "POST", Tokens.AccessUri, null, verifier, CallBackUri));
         }
 
-        private string GetAuthorization(IToken token, string verb, string endpoint, string query = null, string verifier = null)
+        private string GetAuthorization(IToken token, string verb, string endpoint, string query = null, string verifier = null, string callback = null)
         {
             var uri = new UriBuilder(BaseUri)
             {
@@ -87,7 +87,7 @@ namespace Xero.Api.Example.Applications
                 uri.Query = query.TrimStart('?');
             }
 
-            return CreateSignature(token, verb, uri.Uri, verifier);
+            return CreateSignature(token, verb, uri.Uri, verifier, callback);
         }
     }
 }

--- a/Xero.Api/Infrastructure/OAuth/Signing/HmacSha1Signer.cs
+++ b/Xero.Api/Infrastructure/OAuth/Signing/HmacSha1Signer.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
 {
     public class HmacSha1Signer
     {
-        public string CreateSignature(IToken token, Uri uri, string verb, string verifier = null)
+        public string CreateSignature(IToken token, Uri uri, string verb, string verifier = null, string callback = null)
         {
             var oAuthParameters = new OAuthParameters(
                 new ConsumerKey(token.ConsumerKey),
@@ -22,7 +22,8 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
                 string.Empty,
                 "1.0",
                 verifier,
-                token.Session);
+                token.Session,
+                callback);
 
             var signatureBaseString =
                 new SignatureBaseString(

--- a/Xero.Api/Infrastructure/OAuth/Signing/RsaSha1Signer.cs
+++ b/Xero.Api/Infrastructure/OAuth/Signing/RsaSha1Signer.cs
@@ -12,7 +12,7 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
 {
     public class RsaSha1Signer
     {
-        public string CreateSignature(X509Certificate2 certificate, IToken token, Uri uri, string verb, string verifier = null)
+        public string CreateSignature(X509Certificate2 certificate, IToken token, Uri uri, string verb, string verifier = null, string callback = null)
         {
             var oAuthParameters = new OAuthParameters(
                 new ConsumerKey(token.ConsumerKey),
@@ -23,7 +23,8 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
                 string.Empty,
                 "1.0",
                 verifier,
-                token.Session);
+                token.Session,
+                callback);
 
             var signatureBaseString =
                 new SignatureBaseString(

--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/Name.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/Name.cs
@@ -11,6 +11,7 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
         internal static Name Timestamp = new Name("timestamp");
         internal static Name Verifier = new Name("verifier");
         internal static Name Session = new Name("session_handle");
+        internal static Name CallBack = new Name("callback");
         public static Name Nonce = new Name("nonce");
 		internal static Name Signature = new Name("signature");
 

--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/OAuthParameters.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/OAuthParameters.cs
@@ -12,6 +12,7 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 	    private string _signature;
     	private readonly string _version;
         private readonly string _nonce, _timestamp, _verifier, _session;
+        private string _callback;
 
 	    public static OAuthParameters Empty = new OAuthParameters(
 	        new ConsumerKey(string.Empty), 
@@ -20,7 +21,8 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 	        new DefaultTimestampSequence(), 
 	        new DefaultNonceSequence(), 
 	        string.Empty, 
-	        null            
+	        null,
+            string.Empty
         );
 
 	    public OAuthParameters(
@@ -32,7 +34,8 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 			string signature, 
 			string version,
             string verifier = null,
-            string session = null
+            string session = null,
+            string callback = null
 		)
         {
     	    _key = key;
@@ -45,6 +48,7 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 
     	    _nonce = nonces.Next();
     	    _timestamp = timestamps.Next();
+            _callback = callback;
         }
 
 	    internal Parameters List() {
@@ -70,6 +74,10 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
                     {
                         it.Add(Session);
                     }
+                    if (!string.IsNullOrWhiteSpace(_callback))
+                    {
+                        it.Add(Callback);
+                    }
                 });
     	}
 
@@ -88,6 +96,11 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 		public void SetSignature(string what) {
 			_signature = what;
 		}
+
+        public void SetCallBackUrl(string url)
+        {
+            _callback = url;
+        }
 
 		internal Parameter Signature {
     		get { return new Parameter(Name.Signature, _signature); }
@@ -113,6 +126,11 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
         internal Parameter Session
         {
             get { return new Parameter(Name.Session, _session); }
+        }
+
+        internal Parameter Callback
+        {
+            get { return new Parameter(Name.CallBack, _callback); }
         }
     }
 }

--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Http/AuthorizationHeader.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Http/AuthorizationHeader.cs
@@ -26,7 +26,8 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Http {
 					Timestamp,
 					Nonce,
 					Version,
-                    Verifier
+                    Verifier,
+                    Callback
 				);
 			}
 		}
@@ -50,6 +51,11 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Http {
 		private string Signature {
 			get { return ToString(_oAuthParameters.Signature); }
 		}
+
+        private string Callback
+        {
+            get { return ToString(_oAuthParameters.Callback); }
+        }
 
 		private string SignatureMethod {
 			get { return ToString(_oAuthParameters.SignatureMethod); }


### PR DESCRIPTION
The new API wrapper is quite well written and straight forward to integrate with however it didn't support the callback redirection required by my app. I have made these changes and have successfully processed the callback redirection.
Ideally there should be a sample web app to demonstrate the integration but I didn't attempt to include it. Hopefully later releases will include an example. 
In my case I just used my app to test end to end oAuth including call back redirection step.
