### PR TITLE
AuthorizationHeader string handling causing OAuth failures

### DIFF
--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Http/AuthorizationHeader.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Http/AuthorizationHeader.cs
@@ -95,10 +95,11 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Http {
 	    }
 	    
 		private bool HasRealm {
-			get { return _realm != null; }
+			get { return !string.IsNullOrWhiteSpace(_realm); }
 		}
 
 		private string ToString(Parameter parameter) {
+            if (string.IsNullOrWhiteSpace(parameter.Value)) return string.Empty;
 			return string.Format(
 				"{0}=\"{1}\"", 
 				parameter.Name, 


### PR DESCRIPTION
When using the Private Application sample code I was receiving an OAuth error.

Failed to validate signature: (http://developer.xero.com/documentation/getting-started/oauth-issues/)
oauth_problem=signature_invalid&oauth_problem_advice=Failed to validate signature

I eventually tracked down the problem to Realm and Callback being included in the Authorization Header even though they were not set

I therefore propose the following changes to the AuthoizationHeader class to prevent the values being appended if not set:

1) Change HasRealm to use IsNullOrWhiteSpace
2) Added guard clause to ToString so that {ParamName}="" is not output if
{ParamValue} is not present

This change fixes the issue for me locally, tested against demo account

This is my first pull request so go easy :-)

Paul
