### PR TITLE
Add PlannedPaymentDate to Invoice model

### DIFF
--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -38,6 +38,9 @@ namespace Xero.Api.Core.Model
         public DateTime? ExpectedPaymentDate { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public DateTime? PlannedPaymentDate { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public decimal? SubTotal { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
http://developer.xero.com/documentation/api/invoices/#title1 Invoices have a property called PlannedPaymentDate, which is the AP equivalent of ExpectedPaymentDate. I added it to the Invoice model, which is enough to have it round-tripped from the API.
