### PR TITLE
Pretty sure ReportType is supposed to be a NamedReportType

### DIFF
--- a/Xero.Api/Core/Model/Reports/Report.cs
+++ b/Xero.Api/Core/Model/Reports/Report.cs
@@ -15,7 +15,7 @@ namespace Xero.Api.Core.Model.Reports
         public string ReportName { get; set; }
 
         [DataMember]
-        public ReportRowType ReportType { get; set; }
+        public NamedReportType ReportType { get; set; }
 
         [DataMember]
         public List<string> ReportTitles { get; set; }


### PR DESCRIPTION
Pretty sure ReportType is supposed to be a NamedReportType not a ReportRowType. It was throwing an exception which was being swallowed by ServiceStack that it couldn't deserialise "BankSummary" (I was calling the BankSummary report) into a ReportRowType. This looks like the type it is supposed to be, ReportRowType is definitely wrong though.
