### PR TITLE
Fix for failed to validate signature exception when where clause contains a comma (,)

### DIFF
--- a/Xero.Api/Core/File/BinaryFile.cs
+++ b/Xero.Api/Core/File/BinaryFile.cs
@@ -25,7 +25,10 @@ namespace Xero.Api.Core.File
                 throw new FileNotFoundException("The file could not be found", fileInfo.FullName);
             }
 
-            CopyData(fileInfo.OpenRead(), fileInfo.Name, MimeTypes.GetMimeType(fileInfo), (int)fileInfo.Length);
+            using (FileStream fileStream = fileInfo.OpenRead())
+            {
+                CopyData(fileStream, fileInfo.Name, MimeTypes.GetMimeType(fileInfo), (int)fileInfo.Length);
+            }
         }
 
         public BinaryFile(Stream content, string filename, string contentType, int length)

--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -53,6 +53,9 @@ namespace Xero.Api.Core.Model
         public string CurrencyCode { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public decimal? CurrencyRate { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public DateTime? FullyPaidOnDate { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/RequestParameters.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/RequestParameters.cs
@@ -24,11 +24,11 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
 
     	private IEnumerable<Parameter> Map(string key)
         {
-    		return ValueFor(key).Split(',').Select(v => new Parameter(key, v));
+    		return ValuesFor(key).Select(v => new Parameter(key, v));
         }
 
-    	private string ValueFor(string key) {
-    		return _values[key];
+    	private string[] ValuesFor(string key) {
+    		return _values.GetValues(key);
     	}
 
     	#region Implementation of IEnumerable


### PR DESCRIPTION
This fix resolves an issue whereby finding contacts using the where clause "TaxNumber != NULL AND TaxNumber.Replace(" ","") == "1234"", and other various object types, throws a Failed to validate signature exception due to the query string being incorrectly split into multiple request parameters.