### PR TITLE
Changed SuperannuationLine Model AccountCode properties from int to string

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
@@ -20,10 +20,10 @@ namespace Xero.Api.Payroll.Australia.Model
         public decimal MinimumMonthlyEarnings { get; set; }
 
         [DataMember]
-        public int ExpenseAccountCode { get; set; }
+        public string ExpenseAccountCode { get; set; }
 
         [DataMember]
-        public int LiabilityAccountCode { get; set; }
+        public string LiabilityAccountCode { get; set; }
 
         [DataMember]
         public DateTime? PaymentDateForThisPeriod { get; set; }


### PR DESCRIPTION
Riley has confirmed to me that these properties are a bug in the wrapper and should be strings as both string characters are valid in an AccountCode. Both the UI and the API will accept strings.