### PR TITLE
Added default NonSystemAccount value to the SystemAccountType enum

### DIFF
--- a/Xero.Api/Core/Model/Types/SystemAccountType.cs
+++ b/Xero.Api/Core/Model/Types/SystemAccountType.cs
@@ -5,6 +5,7 @@ namespace Xero.Api.Core.Model.Types
     [DataContract(Namespace = "")]
     public enum SystemAccountType
     {
+        NonSystemAccount = 0,
         [EnumMember(Value = "DEBTORS")]
         Debtors,
         [EnumMember(Value = "CREDITORS")]


### PR DESCRIPTION
Added NonSystemAccount value to the SystemAccountType enum to correctly set the default value when deserializing accounts. Previously all non system accounts were assigned the value 'Debtors', which made it difficult to determine the actual debtors system account.