### PR TITLE
Added IHasId interface to core models

### DIFF
--- a/Xero.Api/Common/IHasId.cs
+++ b/Xero.Api/Common/IHasId.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Xero.Api.Common
+{
+    public interface IHasId
+    {
+        Guid Id { get; set; }
+    }
+}

--- a/Xero.Api/Core/Model/Account.cs
+++ b/Xero.Api/Core/Model/Account.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Account
+    public class Account : IHasId
     {
         [DataMember(Name = "AccountID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Attachment.cs
+++ b/Xero.Api/Core/Model/Attachment.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.File;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public sealed class Attachment : BinaryFile
+    public sealed class Attachment : BinaryFile, IHasId
     {
         public Attachment(FileInfo fileInfo) : base(fileInfo)
         {

--- a/Xero.Api/Core/Model/BankTransaction.cs
+++ b/Xero.Api/Core/Model/BankTransaction.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class BankTransaction : HasUpdatedDate
+    public class BankTransaction : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "BankTransactionID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/BankTransfer.cs
+++ b/Xero.Api/Core/Model/BankTransfer.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class BankTransfer
+    public class BankTransfer : IHasId
     {
         [DataMember(Name = "BankTransferID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Contact.cs
+++ b/Xero.Api/Core/Model/Contact.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Status;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Contact : HasUpdatedDate
+    public class Contact : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ContactID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ContactGroup.cs
+++ b/Xero.Api/Core/Model/ContactGroup.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class ContactGroup
+    public class ContactGroup : IHasId
     {
         [DataMember(Name = "ContactGroupID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/CreditNote.cs
+++ b/Xero.Api/Core/Model/CreditNote.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class CreditNote : HasUpdatedDate
+    public class CreditNote : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "CreditNoteID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Employee.cs
+++ b/Xero.Api/Core/Model/Employee.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Employee
+    public class Employee : IHasId
     {
         [DataMember(Name = "EmployeeID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ExpenseClaim.cs
+++ b/Xero.Api/Core/Model/ExpenseClaim.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Status;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class ExpenseClaim : HasUpdatedDate
+    public class ExpenseClaim : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ExpenseClaimID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Invoice : HasUpdatedDate
+    public class Invoice : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "InvoiceID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Item.cs
+++ b/Xero.Api/Core/Model/Item.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public sealed class Item
+    public sealed class Item : IHasId
     {
         [DataMember(Name = "ItemID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ItemTrackingCategory.cs
+++ b/Xero.Api/Core/Model/ItemTrackingCategory.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "", Name = "TrackingCategory")]
-    public class ItemTrackingCategory
+    public class ItemTrackingCategory : IHasId
     {
         [DataMember(Name = "TrackingCategoryID")]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Journal.cs
+++ b/Xero.Api/Core/Model/Journal.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Journal
+    public class Journal : IHasId
     {
         [DataMember(Name = "JournalID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Line.cs
+++ b/Xero.Api/Core/Model/Line.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Name = "JournalLine", Namespace = "")]
-    public class Line
+    public class Line : IHasId
     {
         [DataMember(Name = "JournalLineID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ManualJournal.cs
+++ b/Xero.Api/Core/Model/ManualJournal.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class ManualJournal : HasUpdatedDate
+    public class ManualJournal : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ManualJournalID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Option.cs
+++ b/Xero.Api/Core/Model/Option.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Option
+    public class Option : IHasId
     {
         [DataMember(Name = "TrackingOptionID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Payment.cs
+++ b/Xero.Api/Core/Model/Payment.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Payment : HasUpdatedDate
+    public class Payment : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "PaymentID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Receipt.cs
+++ b/Xero.Api/Core/Model/Receipt.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Receipt : HasUpdatedDate
+    public class Receipt : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ReceiptID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/RepeatingInvoice.cs
+++ b/Xero.Api/Core/Model/RepeatingInvoice.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class RepeatingInvoice
+    public class RepeatingInvoice : IHasId
     {
         [DataMember(Name = "RepeatingInvoiceID", EmitDefaultValue = false)]
         public Guid Id { set; get; }

--- a/Xero.Api/Core/Model/TrackingCategory.cs
+++ b/Xero.Api/Core/Model/TrackingCategory.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class TrackingCategory
+    public class TrackingCategory : IHasId
     {
         [DataMember(Name = "TrackingCategoryID")]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/User.cs
+++ b/Xero.Api/Core/Model/User.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class User
+    public class User : IHasId
     {
         [DataMember(Name = "UserID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\IHasId.cs" />
     <Compile Include="Common\QueryGenerator.cs" />
     <Compile Include="Core\Endpoints\AllocationEndpoint.cs" />
     <Compile Include="Core\Endpoints\Base\FourDecimalPlacesEndpoint.cs" />


### PR DESCRIPTION
Added an IHasId interface to all core models that have an Id property. Amongst other uses this can be used in generic constraints to allow generics to access the Id property. 

I did not apply this to the BrandingTheme or ContactPerson models as I noticed that their Id properties are not named Id (instead they are BrandingThemeId and ContactPersonId). As such I didn't know whether they should be changed to Id to be consistent with the other models, or whether an new Id property should be added that redirects to the existing one.