### PR TITLE
Enum fields added for missing payment types

### DIFF
--- a/Xero.Api/Core/Model/Types/PaymentType.cs
+++ b/Xero.Api/Core/Model/Types/PaymentType.cs
@@ -7,6 +7,10 @@ namespace Xero.Api.Core.Model.Types
         [EnumMember(Value = "ACCPAYPAYMENT")]
         AccountsPayable,
         [EnumMember(Value = "ACCRECPAYMENT")]
-        AccountsRecievable
+        AccountsReceivable
+        [EnumMember(Value = "APCREDITPAYMENT")]
+        AccountsPayableCredit,
+        [EnumMember(Value = "ARCREDITPAYMENT")]
+        AccountsReceivableCredit,
     }
 }


### PR DESCRIPTION
AR and AP credit payments were defaulting to PaymentType.AccountsPayable due to missing enum fields.