### PR TITLE
ModifiedSince incorrectly retained between calls?

### DIFF
--- a/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
@@ -52,10 +52,7 @@ namespace Xero.Api.Infrastructure.Http
         public IEnumerable<TResult> Get<TResult, TResponse>(string endPoint)
             where TResponse : IXeroResponse<TResult>, new()
         {
-            if (ModifiedSince.HasValue)
-            {
-                Client.ModifiedSince = ModifiedSince.Value;
-            }
+            Client.ModifiedSince = ModifiedSince.Value;
 
             return Read<TResult, TResponse>(Client.Get(endPoint, new QueryGenerator(Where, Order, Parameters).UrlEncodedQueryString));
         }


### PR DESCRIPTION
Setting the 'modified since' date once using the XeroReadEndpoint.ModifiedSince call retains the date/time value for future calls that don't specify a 'modified since' time.
Removed the not-null check as null is a valid value.