### PR TITLE
Fix bad merge from changeset 310b0be54f4217dc6791c3f5e27ad61abae518b7.  ...

### DIFF
--- a/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
@@ -52,7 +52,7 @@ namespace Xero.Api.Infrastructure.Http
         public IEnumerable<TResult> Get<TResult, TResponse>(string endPoint)
             where TResponse : IXeroResponse<TResult>, new()
         {
-            Client.ModifiedSince = ModifiedSince.Value;
+            Client.ModifiedSince = ModifiedSince;
 
             return Read<TResult, TResponse>(Client.Get(endPoint, new QueryGenerator(Where, Order, Parameters).UrlEncodedQueryString));
         }


### PR DESCRIPTION
...ModifiedSince.Value will throw an exception if ModifiedSince is actually null?  Simply assignment should suffice.