### PR TITLE
Fix up generic list declarations for items with Allocations

### DIFF
--- a/Xero.Api/Core/Model/CreditNote.cs
+++ b/Xero.Api/Core/Model/CreditNote.cs
@@ -74,6 +74,6 @@ namespace Xero.Api.Core.Model
         public List<LineItem> LineItems { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public List<Allocation> Allocations { get; set; }
+        public List<CreditNoteAllocation> Allocations { get; set; }
     }
 }

--- a/Xero.Api/Core/Model/Overpayment.cs
+++ b/Xero.Api/Core/Model/Overpayment.cs
@@ -53,6 +53,6 @@ namespace Xero.Api.Core.Model
         public bool? HasAttachments { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public List<PrepaymentAllocation> Allocations { get; set; }
+        public List<OverpaymentAllocation> Allocations { get; set; }
     }
 }


### PR DESCRIPTION
Reflect the correct container types (CreditNote / Overpayment).