### PR TITLE
OverpaymentStatus Fixes

### DIFF
--- a/Xero.Api/Core/Model/Overpayment.cs
+++ b/Xero.Api/Core/Model/Overpayment.cs
@@ -19,7 +19,7 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public DateTime? Date { get; set; }
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public OverpaymentStatus Status { get; set; }
 
         [DataMember]
@@ -43,7 +43,7 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public decimal? CurrencyRate { get; set; }
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public OverpaymentType Type { get; set; }
 
         [DataMember]

--- a/Xero.Api/Core/Model/Status/OverpaymentStatus.cs
+++ b/Xero.Api/Core/Model/Status/OverpaymentStatus.cs
@@ -7,7 +7,9 @@ namespace Xero.Api.Core.Model.Status
     {
         [EnumMember(Value = "AUTHORISED")]
         Authorised,
-        [EnumMember(Value = "DELETED")]
-        Deleted
+        [EnumMember(Value = "PAID")]
+        Paid,
+        [EnumMember(Value = "VOIDED")]
+        Voided
     }
 }


### PR DESCRIPTION
    Issue : OverpaymentStatus enum values do not reflect the API

- Align the OverpaymentStatus enum with the API response definitions; DELETED doesn't exist as a status code as documented: http://developer.xero.com/documentation/api/types/#OverpaymentStatuses.  
- Added missing PAID status.