### PR TITLE
Swap inheritance order of CoreData and HasUpdatedDate

### DIFF
--- a/Xero.Api/Common/CoreData.cs
+++ b/Xero.Api/Common/CoreData.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 using Xero.Api.Infrastructure.Model;
 
-namespace Xero.Api.Core.Model
+namespace Xero.Api.Common
 {
     [DataContract(Namespace = "")]
-    public abstract class CoreData : HasUpdatedDate
+    public abstract class CoreData
     {
         [DataMember(EmitDefaultValue = false, Name = "ValidationErrors")]
         public List<ValidationError> Errors { get; set; }

--- a/Xero.Api/Common/HasUpdatedDate.cs
+++ b/Xero.Api/Common/HasUpdatedDate.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Xero.Api.Common
 {
     [DataContract(Namespace = "")]
-    public abstract class HasUpdatedDate
+    public abstract class HasUpdatedDate : CoreData
     {
         [DataMember(Name = "UpdatedDateUTC", EmitDefaultValue = false)]
         public DateTime? UpdatedDateUtc { get; set; }

--- a/Xero.Api/Core/Model/Address.cs
+++ b/Xero.Api/Core/Model/Address.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model

--- a/Xero.Api/Core/Model/AllocationBase.cs
+++ b/Xero.Api/Core/Model/AllocationBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/Balance.cs
+++ b/Xero.Api/Core/Model/Balance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/Balances.cs
+++ b/Xero.Api/Core/Model/Balances.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/BankTransaction.cs
+++ b/Xero.Api/Core/Model/BankTransaction.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class BankTransaction : CoreData, IHasId
+    public class BankTransaction : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "BankTransactionID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/BatchPayments.cs
+++ b/Xero.Api/Core/Model/BatchPayments.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/BrandingTheme.cs
+++ b/Xero.Api/Core/Model/BrandingTheme.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/Contact.cs
+++ b/Xero.Api/Core/Model/Contact.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Status;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Contact : CoreData, IHasId
+    public class Contact : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ContactID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ContactPerson.cs
+++ b/Xero.Api/Core/Model/ContactPerson.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/CreditNote.cs
+++ b/Xero.Api/Core/Model/CreditNote.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class CreditNote : CoreData, IHasId
+    public class CreditNote : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "CreditNoteID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Currency.cs
+++ b/Xero.Api/Core/Model/Currency.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/ExpenseClaim.cs
+++ b/Xero.Api/Core/Model/ExpenseClaim.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Status;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class ExpenseClaim : CoreData, IHasId
+    public class ExpenseClaim : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ExpenseClaimID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ExternalLink.cs
+++ b/Xero.Api/Core/Model/ExternalLink.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model

--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Invoice : CoreData, IHasId
+    public class Invoice : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "InvoiceID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/ItemDetails.cs
+++ b/Xero.Api/Core/Model/ItemDetails.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/ItemDetails.cs
+++ b/Xero.Api/Core/Model/ItemDetails.cs
@@ -4,7 +4,7 @@ using Xero.Api.Common;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public abstract class ItemDetails : CoreData
+    public abstract class ItemDetails : HasUpdatedDate
     {
         [DataMember(EmitDefaultValue = false)]
         public decimal UnitPrice { get; set; }

--- a/Xero.Api/Core/Model/LineItem.cs
+++ b/Xero.Api/Core/Model/LineItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/ManualJournal.cs
+++ b/Xero.Api/Core/Model/ManualJournal.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class ManualJournal : CoreData, IHasId
+    public class ManualJournal : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ManualJournalID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Overpayment.cs
+++ b/Xero.Api/Core/Model/Overpayment.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Overpayment : CoreData, IHasId
+    public class Overpayment : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "OverpaymentID")]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Payment.cs
+++ b/Xero.Api/Core/Model/Payment.cs
@@ -7,7 +7,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Payment : CoreData, IHasId
+    public class Payment : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "PaymentID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/PaymentTerms.cs
+++ b/Xero.Api/Core/Model/PaymentTerms.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/Phone.cs
+++ b/Xero.Api/Core/Model/Phone.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model

--- a/Xero.Api/Core/Model/Prepayment.cs
+++ b/Xero.Api/Core/Model/Prepayment.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Prepayment : CoreData, IHasId
+    public class Prepayment : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "PrepaymentID")]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Receipt.cs
+++ b/Xero.Api/Core/Model/Receipt.cs
@@ -8,7 +8,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class Receipt : CoreData, IHasId
+    public class Receipt : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "ReceiptID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Core/Model/Schedule.cs
+++ b/Xero.Api/Core/Model/Schedule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model

--- a/Xero.Api/Core/Model/TaxComponent.cs
+++ b/Xero.Api/Core/Model/TaxComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 
 namespace Xero.Api.Core.Model
 {

--- a/Xero.Api/Core/Model/TaxRate.cs
+++ b/Xero.Api/Core/Model/TaxRate.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Status;
 using Xero.Api.Core.Model.Types;
 

--- a/Xero.Api/Core/Model/Terms.cs
+++ b/Xero.Api/Core/Model/Terms.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
 using Xero.Api.Core.Model.Types;
 
 namespace Xero.Api.Core.Model

--- a/Xero.Api/Core/Model/User.cs
+++ b/Xero.Api/Core/Model/User.cs
@@ -6,7 +6,7 @@ using Xero.Api.Core.Model.Types;
 namespace Xero.Api.Core.Model
 {
     [DataContract(Namespace = "")]
-    public class User : CoreData, IHasId
+    public class User : HasUpdatedDate, IHasId
     {
         [DataMember(Name = "UserID", EmitDefaultValue = false)]
         public Guid Id { get; set; }

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -62,7 +62,7 @@
     <Compile Include="Core\Model\PrepaymentAllocation.cs" />
     <Compile Include="Core\Model\Status\OverpaymentStatus.cs" />
     <Compile Include="Core\Model\Types\OverpaymentType.cs" />
-    <Compile Include="Core\Model\CoreData.cs" />
+    <Compile Include="Common\CoreData.cs" />
     <Compile Include="Core\Model\Status\ValidationStatus.cs" />
     <Compile Include="Core\Response\OverpaymentsResponse.cs" />
     <Compile Include="Core\Response\PrepaymentsResponse.cs" />


### PR DESCRIPTION
Swapped inheritance order of CoreData and HasUpdatedDate classes, as the change introduced in #53 caused all model classes to derive from HasUpdatedDate, making it not possible to determine which models actually support update dates.