### PR TITLE
Store the body of the Response after reading the stream.

### DIFF
--- a/Xero.Api/Infrastructure/Http/Response.cs
+++ b/Xero.Api/Infrastructure/Http/Response.cs
@@ -6,6 +6,8 @@ namespace Xero.Api.Infrastructure.Http
 {
     internal class Response
     {
+	    private string _body;
+
         internal Response(HttpWebResponse inner)
         {
             StatusCode = inner.StatusCode;
@@ -26,14 +28,20 @@ namespace Xero.Api.Infrastructure.Http
         {
             get
             {
+	            if (_body != null)
+		            return _body;
+
+				//Cache the body so it can be examined more than once when debugging
                 using (var rdr = new StreamReader(Stream))
                 {
                     var result = rdr.ReadToEnd();
 
                     Stream.Seek(0, SeekOrigin.Begin);
                         
-                    return result;
+                    _body = result;
                 }
+
+	            return _body;
             }
         }
 


### PR DESCRIPTION
Gives the ability to read the body of a Response more than once. Useful for when inspecting the Response when debugging