### PR TITLE
Add LineItems to Invoice.cs and make Items obselete. 

### DIFF
--- a/CoreTests/Integration/Attachments/Attachments.cs
+++ b/CoreTests/Integration/Attachments/Attachments.cs
@@ -130,7 +130,7 @@ namespace CoreTests.Integration.Attachments
             {
                 Contact = new Contact { Name = "Richard" },
                 Type = accRec ? InvoiceType.AccountsReceivable : InvoiceType.AccountsPayable,
-                Items = new List<LineItem>
+                LineItems = new List<LineItem>
                 {
                     new LineItem
                     {

--- a/CoreTests/Integration/General/Errors.cs
+++ b/CoreTests/Integration/General/Errors.cs
@@ -25,7 +25,7 @@ namespace CoreTests.Integration.General
         {
             Assert.Throws<ValidationException>(() => Api.Invoices.Create(new Invoice
             {
-                Items = new List<LineItem>
+                LineItems = new List<LineItem>
                 {
                     new LineItem
                     {

--- a/CoreTests/Integration/Invoices/Create.cs
+++ b/CoreTests/Integration/Invoices/Create.cs
@@ -44,7 +44,7 @@ namespace CoreTests.Integration.Invoices
             {
                 Contact = new Contact { Name = "ABC Limited" },
                 Type = InvoiceType.AccountsReceivable,
-                Items = new List<LineItem>
+                LineItems = new List<LineItem>
                 {
                     new LineItem
                     {
@@ -65,7 +65,7 @@ namespace CoreTests.Integration.Invoices
 
             Assert.True(invoice.Id != Guid.Empty);
             Assert.AreEqual(InvoiceType.AccountsReceivable, invoice.Type);
-            Assert.AreEqual(2, invoice.Items.Count());
+			Assert.AreEqual(2, invoice.LineItems.Count());
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace CoreTests.Integration.Invoices
                 {
                     Contact = new Contact { Name = "ABC Limited" },
                     Type = InvoiceType.AccountsReceivable,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -92,7 +92,7 @@ namespace CoreTests.Integration.Invoices
                 {
                     Contact = new Contact { Name = "Jack" },
                     Type = InvoiceType.AccountsReceivable,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -117,7 +117,7 @@ namespace CoreTests.Integration.Invoices
                 {
                     Contact = new Contact { Name = "ABC Limited" },
                     Type = InvoiceType.AccountsReceivable,
-                    Items = new List<LineItem>
+					LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -129,7 +129,7 @@ namespace CoreTests.Integration.Invoices
                     }
                 });
 
-            Assert.AreEqual(25.6591m, invoice.Items.First().UnitAmount);
+			Assert.AreEqual(25.6591m, invoice.LineItems.First().UnitAmount);
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace CoreTests.Integration.Invoices
                 {
                     Contact = new Contact { Name = "ABC Limited" },
                     Type = InvoiceType.AccountsReceivable,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -151,10 +151,10 @@ namespace CoreTests.Integration.Invoices
                             Quantity = 1m
                         }
                     }
-                },                
+                }                
             }).ToList();
 
-            Assert.AreEqual(25.66m, invoices.First().Items.First().UnitAmount);
+			Assert.AreEqual(25.66m, invoices.First().LineItems.First().UnitAmount);
         }
 
         [Test]
@@ -188,7 +188,7 @@ namespace CoreTests.Integration.Invoices
                     TotalTax = 10.89m,
                     SubTotal = 87.11m,
                     Total = 98.00m,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -219,14 +219,14 @@ namespace CoreTests.Integration.Invoices
                             TaxType = "OUTPUT2",                            
                         }
                     }
-                },                
+                }                
             }).ToList();
 
             var invoice = Api.Invoices.Find(invoices.First().Id);
 
-            Assert.AreEqual(category, invoice.Items.First().Tracking[0].Id);
-            Assert.AreEqual(name, invoice.Items.First().Tracking[0].Name);
-            Assert.AreEqual(option, invoice.Items.First().Tracking[0].Option);
+			Assert.AreEqual(category, invoice.LineItems.First().Tracking[0].Id);
+			Assert.AreEqual(name, invoice.LineItems.First().Tracking[0].Name);
+			Assert.AreEqual(option, invoice.LineItems.First().Tracking[0].Option);
             Assert.AreEqual(dueDate, invoice.DueDate);
             Assert.AreEqual(paymentDate, invoice.ExpectedPaymentDate);
             Assert.AreEqual(reference, invoice.Reference);
@@ -252,7 +252,7 @@ namespace CoreTests.Integration.Invoices
             {
                 Contact = new Contact { Name = "ABC Limited" },
                 Type = InvoiceType.AccountsReceivable,
-                Items = new List<LineItem>
+				LineItems = new List<LineItem>
                 {
                     new LineItem
                     {
@@ -264,7 +264,7 @@ namespace CoreTests.Integration.Invoices
 
             Assert.True(invoice.Id != Guid.Empty);
             Assert.AreEqual(InvoiceType.AccountsReceivable, invoice.Type);
-            Assert.AreEqual(1, invoice.Items.Count());
+			Assert.AreEqual(1, invoice.LineItems.Count());
         }
     }
 }

--- a/CoreTests/Integration/Invoices/InvoicesTest.cs
+++ b/CoreTests/Integration/Invoices/InvoicesTest.cs
@@ -28,7 +28,7 @@ namespace CoreTests.Integration.Invoices
                 DueDate = DateTime.UtcNow.AddDays(90),
                 LineAmountTypes = LineAmountType.Inclusive,
                 Status = status,
-                Items = new List<LineItem>
+				LineItems = new List<LineItem>
                 {
                     new LineItem
                     {
@@ -47,7 +47,7 @@ namespace CoreTests.Integration.Invoices
             {
                 Contact = new Contact { Name = "Richard" },
                 Type = type,
-                Items = new List<LineItem>
+				LineItems = new List<LineItem>
                 {
                     new LineItem
                     {

--- a/CoreTests/Integration/Invoices/SummarizeErrors.cs
+++ b/CoreTests/Integration/Invoices/SummarizeErrors.cs
@@ -39,7 +39,7 @@ namespace CoreTests.Integration.Invoices
                     DueDate = DateTime.UtcNow.AddDays(90),
                     LineAmountTypes = LineAmountType.Inclusive,
                     Status = status,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {
@@ -61,7 +61,7 @@ namespace CoreTests.Integration.Invoices
                     DueDate = DateTime.UtcNow.AddDays(90),
                     LineAmountTypes = LineAmountType.Inclusive,
                     Status = status,
-                    Items = new List<LineItem>
+                    LineItems = new List<LineItem>
                     {
                         new LineItem
                         {

--- a/CoreTests/Integration/Payments/PaymentsTest.cs
+++ b/CoreTests/Integration/Payments/PaymentsTest.cs
@@ -45,7 +45,7 @@ namespace CoreTests.Integration.Payments
                 DueDate = DateTime.UtcNow.AddDays(90),
                 LineAmountTypes = LineAmountType.Inclusive,
                 Status = InvoiceStatus.Authorised,
-                Items = new List<LineItem>
+				LineItems = new List<LineItem>
                 {
                     new LineItem
                     {

--- a/CoreTests/Integration/TrackingCategories/TrackingCategoriesTest.cs
+++ b/CoreTests/Integration/TrackingCategories/TrackingCategoriesTest.cs
@@ -114,7 +114,7 @@ namespace CoreTests.Integration.TrackingCategories
                 DueDate = DateTime.UtcNow.AddDays(90),
                 LineAmountTypes = LineAmountType.Inclusive,
                 Status = status,
-                Items = new List<LineItem>
+				LineItems = new List<LineItem>
                 {
                     new LineItem
                     {

--- a/Xero.Api.Example.Creation/ApiDataCreation.cs
+++ b/Xero.Api.Example.Creation/ApiDataCreation.cs
@@ -117,7 +117,7 @@ namespace Xero.Api.Example.Creation
                     Date = date,
                     DueDate = date.AddDays(90),
                     LineAmountTypes = Heads(rnd) ? LineAmountType.Inclusive : LineAmountType.Exclusive,
-                    Items = CreateLineItems(maxLineItems, descriptions).ToList()
+                    LineItems = CreateLineItems(maxLineItems, descriptions).ToList()
                 });
             }
 

--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -79,10 +79,17 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public string Reference { get; set; }
 
-        [DataMember(Name = "LineItems", EmitDefaultValue = false)]
-        public List<LineItem> Items { get; set; }
+		[Obsolete("Use LineItems instead. This property will being removed to bring consistency across models that hold line items")]
+        public List<LineItem> Items 
+		{
+			get { return LineItems; }
+			set { LineItems = value; }
+        }
 
-        [DataMember(EmitDefaultValue = false)]
+	    [DataMember(EmitDefaultValue = false)]
+	    public List<LineItem> LineItems { get; set; }
+
+	    [DataMember(EmitDefaultValue = false)]
         public bool? SentToContact { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
Gives consistency accross models that use line items. Change all references of Items in tests etc to LineItems from Items.