### PR TITLE
Add null checks before creating responses from WebException responses.

### DIFF
--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -65,7 +65,12 @@ namespace Xero.Api.Infrastructure.Http
             }
             catch (WebException we)
             {
-                return new Response((HttpWebResponse)we.Response);
+	            if (we.Response != null)
+	            {
+		            return new Response((HttpWebResponse) we.Response);
+	            }
+
+	            throw;
             }
         }
             
@@ -82,7 +87,12 @@ namespace Xero.Api.Infrastructure.Http
             }
             catch (WebException we)
             {
-                return new Response((HttpWebResponse)we.Response);
+	            if (we.Response != null)
+	            {
+		            return new Response((HttpWebResponse) we.Response);
+	            }
+
+	            throw;
             }
         }
 
@@ -95,7 +105,12 @@ namespace Xero.Api.Infrastructure.Http
             }
             catch (WebException we)
             {
-                return new Response((HttpWebResponse)we.Response);
+	            if (we.Response != null)
+	            {
+		            return new Response((HttpWebResponse) we.Response);
+	            }
+
+	            throw;
             }
         }
 
@@ -108,21 +123,31 @@ namespace Xero.Api.Infrastructure.Http
             }
             catch (WebException we)
             {
-                return new Response((HttpWebResponse)we.Response);
+	            if (we.Response != null)
+	            {
+		            return new Response((HttpWebResponse) we.Response);
+	            }
+
+	            throw;
             }
         }
 
         public Response Delete(string endpoint)
         {
-            try
-            {
-                var request = CreateRequest(endpoint, "DELETE");
-                return new Response((HttpWebResponse)request.GetResponse());
-            }
-            catch (WebException we)
-            {
-                return new Response((HttpWebResponse)we.Response);
-            }
+	        try
+	        {
+		        var request = CreateRequest(endpoint, "DELETE");
+		        return new Response((HttpWebResponse) request.GetResponse());
+	        }
+	        catch (WebException we)
+	        {
+		        if (we.Response != null)
+		        {
+			        return new Response((HttpWebResponse) we.Response);
+				}
+
+		        throw;
+	        }
         }
 
         private HttpWebRequest CreateRequest(string endPoint, string method, string accept = "application/json", string query = null)

--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -144,7 +144,7 @@ namespace Xero.Api.Infrastructure.Http
 		        if (we.Response != null)
 		        {
 			        return new Response((HttpWebResponse) we.Response);
-				}
+			}
 
 		        throw;
 	        }


### PR DESCRIPTION
If there is no response throw the exception back up for the client to catch and decide how to handle it.