### PR TITLE
Adds tests around ContactGroups.Find as examples on how to use .Find()

### DIFF
--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Integration\ContactGroups\ContactGroupsTest.cs" />
     <Compile Include="Integration\ContactGroups\Create.cs" />
     <Compile Include="Integration\ContactGroups\Delete.cs" />
+    <Compile Include="Integration\ContactGroups\Find.cs" />
     <Compile Include="Integration\ContactGroups\Remove_Contact.cs" />
     <Compile Include="Integration\ContactGroups\Update.cs" />
     <Compile Include="Integration\Contacts\ContactsTest.cs" />

--- a/CoreTests/Integration/ContactGroups/Find.cs
+++ b/CoreTests/Integration/ContactGroups/Find.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace CoreTests.Integration.ContactGroups
+{
+    [TestFixture]
+    public class Find : ContactGroupsTest
+    {
+        [Test]
+        public void Can_Find_Contact_Group()
+        {
+            var contactGroup = Given_a_contactgroup();
+
+            var foundContactGroup = Api.ContactGroups.Find(contactGroup.Id);
+
+            Assert.IsTrue(foundContactGroup.Name.StartsWith("Nice People"));
+        }
+
+        [Test]
+        public void Can_Find_Contacts_in_Contact_Group()
+        {
+            var contactGroup = Given_a_contactgroup();
+
+            var contact = Given_a_contact();
+
+            Api.ContactGroups[contactGroup.Id].Add(contact);
+
+            var foundContactGroup = Api.ContactGroups.Find(contactGroup.Id);
+
+            Assert.IsTrue(foundContactGroup.Name.StartsWith("Nice People"));
+            Assert.IsTrue(foundContactGroup.Contacts.FirstOrDefault().Name.StartsWith("Peter"));
+        }
+    }
+}


### PR DESCRIPTION
No functional changes. Just a example on how to use ContactGroups.Find() as per ticket request.

@MJMortimer  