### PR TITLE
Added Invoice.Payments

### DIFF
--- a/Xero.Api/Core/Model/Invoice.cs
+++ b/Xero.Api/Core/Model/Invoice.cs
@@ -101,5 +101,8 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public List<Overpayment> Overpayments { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
+        public List<Payment> Payments { get; set; }
+
     }
 }


### PR DESCRIPTION
The invoices API endpoint return an Invoice object that includes a Payments property, but this property was missing from the SDK.  The change in this PR will add this missing property.