### PR TITLE
Stopped Account from being serialized on payments if it is null. Allo…

### DIFF
--- a/Xero.Api/Core/Model/Payment.cs
+++ b/Xero.Api/Core/Model/Payment.cs
@@ -45,7 +45,7 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public Overpayment Overpayment { get; set; }
 
-        [DataMember]
+        [DataMember(EmitDefaultValue = false)]
         public Account Account { get; set; }
     }
 }


### PR DESCRIPTION
…ws payments against invoices to be deleted.

@philals Simple change to stop a Payment's Account from being serialized on a Payment if the Account null. Allows payments on Invoices to be deleted as the POST call to delete it expects only the status change to be given. Without this change the account is serialized meaning both the status and account is given.