### PR TITLE
Change access modifiers for UnauthorizedException and OAuthException

### DIFF
--- a/Xero.Api/Infrastructure/Exceptions/UnauthorizedException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/UnauthorizedException.cs
@@ -2,7 +2,7 @@
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
-    internal class UnauthorizedException
+    public class UnauthorizedException
         : XeroApiException
     {
         public UnauthorizedException(string body)

--- a/Xero.Api/Infrastructure/OAuth/OAuthException.cs
+++ b/Xero.Api/Infrastructure/OAuth/OAuthException.cs
@@ -2,7 +2,7 @@
 
 namespace Xero.Api.Infrastructure.OAuth
 {
-    internal class OAuthException : Exception
+    public class OAuthException : Exception
     {
         public OAuthException(string message) : base (message)
         {


### PR DESCRIPTION
Throwing internal exceptions that aren't being caught and handled, or
throwing other exceptions is a problem
https://msdn.microsoft.com/en-us/library/bb264484.aspx

Doesn't appear that there are any other usages of these exceptions other than just the throw...