### PR TITLE
Rate limiter

### DIFF
--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Integration\Attachments\Attachments.cs" />
     <Compile Include="Integration\General\Errors.cs" />
     <Compile Include="Integration\TaxRates\Create.cs" />
+    <Compile Include="Unit\RateLimiterTest.cs" />
     <Compile Include="Unit\SummarizeErrors.cs" />
     <Compile Include="Unit\UrlEncoder.cs" />
     <Compile Include="Unit\Contacts.cs" />

--- a/CoreTests/Unit/RateLimiterTest.cs
+++ b/CoreTests/Unit/RateLimiterTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Xero.Api.Infrastructure.RateLimiter;
+
+namespace CoreTests.Unit
+{
+    [TestFixture]
+    public class RateLimiterTest
+    {
+        [Test]
+        public void TestRateLimiter()
+        {
+            RateLimiter rate = new RateLimiter(TimeSpan.FromSeconds(5), 5);
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            Assert.IsFalse(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            Assert.IsFalse(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            Assert.IsFalse(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            Assert.IsFalse(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            Assert.IsFalse(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            Assert.IsTrue(rate.CheckLimit());
+            rate.WaitUntilLimit();
+            sw.Stop();
+            Assert.IsTrue(sw.Elapsed > TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/Xero.Api/Common/XeroApi.cs
+++ b/Xero.Api/Common/XeroApi.cs
@@ -1,5 +1,6 @@
 ﻿using Xero.Api.Infrastructure.Http;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 
 namespace Xero.Api.Common
 {
@@ -15,16 +16,16 @@ namespace Xero.Api.Common
             BaseUri = baseUri;
         }
 
-        protected XeroApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+        protected XeroApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
             : this(baseUri)
         {
-            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper);
+            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter);
         }
 
-        protected XeroApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+        protected XeroApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
             : this(baseUri)
         {
-            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper);
+            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter);
         }
 
         public string UserAgent

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -5,6 +5,7 @@ using Xero.Api.Core.Endpoints;
 using Xero.Api.Core.Model;
 using Xero.Api.Core.Model.Setup;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 using Xero.Api.Serialization;
 using Organisation = Xero.Api.Core.Model.Organisation;
 
@@ -14,28 +15,48 @@ namespace Xero.Api.Core
     {
         private OrganisationEndpoint OrganisationEndpoint { get; set; }
 
-        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : this(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }
 
-        public XeroCoreApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public XeroCoreApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : this(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public XeroCoreApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }
 
         public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user)
+            : this(baseUri, auth, consumer, user, null)
+        {
+        }
+
+        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IRateLimiter rateLimiter)
             : this(baseUri, auth, consumer, user, new DefaultMapper(), new DefaultMapper())
         {
-            Connect();
         }
 
         public XeroCoreApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user)
-            : base(baseUri, auth, consumer, user, new DefaultMapper(), new DefaultMapper())
+            : this(baseUri, auth, consumer, user, null)
         {
-            Connect();
+        }
+
+        public XeroCoreApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IRateLimiter rateLimiter)
+            : this(baseUri, auth, consumer, user, new DefaultMapper(), new DefaultMapper(), rateLimiter)
+        {
         }
 
         public AccountsEndpoint Accounts { get; private set; }

--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 
 namespace Xero.Api.Infrastructure.Http
 {
@@ -15,7 +16,8 @@ namespace Xero.Api.Infrastructure.Http
     {
         private readonly string _baseUri;
         private readonly IAuthenticator _auth;
-        
+        private readonly IRateLimiter _rateLimiter;
+
         private readonly Dictionary<string, string> _headers;
 
         public DateTime? ModifiedSince { get; set; }
@@ -27,6 +29,7 @@ namespace Xero.Api.Infrastructure.Http
         {
             _baseUri = baseUri;
             _headers = new Dictionary<string, string>();
+            _rateLimiter = new RateLimiter.RateLimiter(TimeSpan.FromMinutes(1), 60);
         }
         
         public HttpClient(string baseUri, IConsumer consumer, IUser user) : this(baseUri)
@@ -39,6 +42,12 @@ namespace Xero.Api.Infrastructure.Http
             : this(baseUri, consumer, user)
         {
             _auth = auth;
+        }
+
+        public HttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IRateLimiter rateLimiter)
+            : this(baseUri, auth, consumer, user)
+        {
+            _rateLimiter = rateLimiter;
         }
 
         public string UserAgent
@@ -189,6 +198,8 @@ namespace Xero.Api.Infrastructure.Http
             {
                 request.ClientCertificates.Add(ClientCertificate);
             }
+
+            _rateLimiter.WaitUntilLimit();
 
             return request;
         }

--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -29,7 +29,6 @@ namespace Xero.Api.Infrastructure.Http
         {
             _baseUri = baseUri;
             _headers = new Dictionary<string, string>();
-            _rateLimiter = new RateLimiter.RateLimiter(TimeSpan.FromMinutes(1), 60);
         }
         
         public HttpClient(string baseUri, IConsumer consumer, IUser user) : this(baseUri)
@@ -199,7 +198,8 @@ namespace Xero.Api.Infrastructure.Http
                 request.ClientCertificates.Add(ClientCertificate);
             }
 
-            _rateLimiter.WaitUntilLimit();
+            if (_rateLimiter != null)
+                _rateLimiter.WaitUntilLimit();
 
             return request;
         }

--- a/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
@@ -6,6 +6,7 @@ using System.Net;
 using Xero.Api.Common;
 using Xero.Api.Infrastructure.Exceptions;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 
 namespace Xero.Api.Infrastructure.Http
 {
@@ -23,16 +24,28 @@ namespace Xero.Api.Infrastructure.Http
             XmlMapper = xmlMapper;
         }
 
-        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
-            : this(jsonMapper, xmlMapper)
+        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
+            : this(baseUri, auth, consumer, user, jsonMapper, xmlMapper, null)
         {
-            Client = new HttpClient(baseUri, auth, consumer, user);
         }
 
-        public XeroHttpClient(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
+        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper, IRateLimiter rateLimiter)
             : this(jsonMapper, xmlMapper)
         {
-            Client = new HttpClient(baseUri, auth, consumer, user)
+            Client = new HttpClient(baseUri, auth, consumer, user, rateLimiter);
+        }
+
+        public XeroHttpClient(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
+            : this(baseUri, auth, consumer, user, jsonMapper, xmlMapper, null)
+        {
+        }
+
+        public XeroHttpClient(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper, IRateLimiter rateLimiter)
+            : this(jsonMapper, xmlMapper)
+        {
+            Client = new HttpClient(baseUri, auth, consumer, user, rateLimiter)
             {
                 ClientCertificate = auth.Certificate
             };

--- a/Xero.Api/Infrastructure/RateLimiter/IRateLimiter.cs
+++ b/Xero.Api/Infrastructure/RateLimiter/IRateLimiter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Xero.Api.Infrastructure.RateLimiter
+{
+    interface IRateLimiter
+    {
+        void WaitUntilLimit();
+
+        bool CheckLimit();
+    }
+}

--- a/Xero.Api/Infrastructure/RateLimiter/IRateLimiter.cs
+++ b/Xero.Api/Infrastructure/RateLimiter/IRateLimiter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Xero.Api.Infrastructure.RateLimiter
 {
-    interface IRateLimiter
+    public interface IRateLimiter
     {
         void WaitUntilLimit();
 

--- a/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
+++ b/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Xero.Api.Infrastructure.RateLimiter
+{
+    public class RateLimiter : IRateLimiter
+    {
+        public TimeSpan Duration { get; }
+        public int Qty { get; }
+
+        readonly List<DateTime> rateLimiter = null;
+
+        /// <summary>
+        /// Create an instance of this class that allows x requests over y seconds
+        /// </summary>
+        /// <param name="duration"></param>
+        /// <param name="qty"></param>
+        public RateLimiter(TimeSpan duration, int qty)
+        {
+            this.Duration = duration;
+            this.Qty = qty;
+            this.rateLimiter = new List<DateTime>(Qty);
+        }
+
+        public RateLimiter() : this(TimeSpan.FromMinutes(1), 60) { }
+
+        /// <summary>
+        /// Don't return from this method until we're back under the limit
+        /// </summary>
+        public void WaitUntilLimit()
+        {
+            while (rateLimiter.Count >= Qty)
+            {
+                var diff = rateLimiter[0].Add(Duration) - DateTime.UtcNow;
+                if (diff.TotalMilliseconds > 0)
+                    Thread.Sleep((int)diff.TotalMilliseconds + 1000);
+                rateLimiter.RemoveAt(0);
+            }
+            rateLimiter.Add(DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Check whether we've used up all of the allocation
+        /// </summary>
+        /// <returns>True if we're over the limit, false if we've got some allocation left</returns>
+        public bool CheckLimit()
+        {
+            return (rateLimiter.Count >= Qty && rateLimiter[0].Add(Duration) > DateTime.UtcNow);
+        }
+    }
+}

--- a/Xero.Api/Payroll/AmericanPayroll.cs
+++ b/Xero.Api/Payroll/AmericanPayroll.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 using Xero.Api.Payroll.America.Endpoints;
 using Xero.Api.Payroll.America.Model;
 using Xero.Api.Payroll.Common;
@@ -11,14 +12,26 @@ namespace Xero.Api.Payroll
 {
     public class AmericanPayroll : PayrollApi
     {
-        public AmericanPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public AmericanPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : this(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public AmericanPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }
 
-        public AmericanPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public AmericanPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public AmericanPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Payroll/AustralianPayroll.cs
+++ b/Xero.Api/Payroll/AustralianPayroll.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 using Xero.Api.Payroll.Australia.Endpoints;
 using Xero.Api.Payroll.Australia.Model;
 using Xero.Api.Payroll.Common;
@@ -11,14 +12,26 @@ namespace Xero.Api.Payroll
 {
     public class AustralianPayroll : PayrollApi
     {
-        public AustralianPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public AustralianPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : this(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public AustralianPayroll(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }
 
-        public AustralianPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        public AustralianPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user,
+            IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
+            : this(baseUri, auth, consumer, user, readMapper, writeMapper, null)
+        {
+        }
+
+        public AustralianPayroll(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
             Connect();
         }

--- a/Xero.Api/Payroll/Common/PayrollApi.cs
+++ b/Xero.Api/Payroll/Common/PayrollApi.cs
@@ -1,17 +1,18 @@
 ﻿using Xero.Api.Common;
 using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Infrastructure.RateLimiter;
 
 namespace Xero.Api.Payroll.Common
 {
     public abstract class PayrollApi : XeroApi
     {
-        protected PayrollApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        protected PayrollApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
         }
 
-        protected PayrollApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper)
+        protected PayrollApi(string baseUri, ICertificateAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
         {
         }
     }

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -227,6 +227,8 @@
     <Compile Include="Infrastructure\Interfaces\ITokenStore.cs" />
     <Compile Include="Infrastructure\Exceptions\XeroApiException.cs" />
     <Compile Include="Core\Endpoints\BrandingThemesEndpoint.cs" />
+    <Compile Include="Infrastructure\RateLimiter\IRateLimiter.cs" />
+    <Compile Include="Infrastructure\RateLimiter\RateLimiter.cs" />
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\UrlEncoder.cs" />
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\HttpEncoder.cs" />
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\HttpUtility.cs" />


### PR DESCRIPTION
The API enforces that no more than 60 requests can be made over a 60 second period. It's useful to have the option for the API to handle that if you are making lots of requests, as the delay can be more convenient than the exception and retrying.

Note that this would also work for the daily limit, but would probably need refactoring so that you'd know to not block for many hours.

Happy to make any modifications based on feedback, but this is a feature we'd really like to see in the core wrapper.