### PR TITLE
SystemAccountType enum value correction

### DIFF
--- a/Xero.Api/Core/Model/Types/SystemAccountType.cs
+++ b/Xero.Api/Core/Model/Types/SystemAccountType.cs
@@ -31,5 +31,5 @@ namespace Xero.Api.Core.Model.Types
         UnrealisedCurrencyGain,
         [EnumMember(Value = "WAGEPAYABLES")]
         WagePayables,
-    }
+    } 
 }


### PR DESCRIPTION
SystemAccountType.cs incorrectly set to Tax rather than GST for 'GST /
VAT' and 'GST On Imports' as per documentation:
http://developer.xero.com/documentation/api/types/#SystemAccounts