### PR TITLE
Add Payments property to ExpenseClaim

### DIFF
--- a/Xero.Api/Core/Model/ExpenseClaim.cs
+++ b/Xero.Api/Core/Model/ExpenseClaim.cs
@@ -35,5 +35,8 @@ namespace Xero.Api.Core.Model
 
         [DataMember(EmitDefaultValue = false)]
         public List<Receipt> Receipts { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<Payment> Payments { get; set; }
     }
 }


### PR DESCRIPTION
As suggested by Xero Developer support team, I have added Payments property to ExpenseClaims.
Tested locally and it worked fine.
Please merge the change into your master branch.