### PR TITLE
Added Paid and Voided statuses to PrepaymentStatus and remove Deleted…

### DIFF
--- a/Xero.Api/Core/Model/Status/PrepaymentStatus.cs
+++ b/Xero.Api/Core/Model/Status/PrepaymentStatus.cs
@@ -7,7 +7,9 @@ namespace Xero.Api.Core.Model.Status
     {
         [EnumMember(Value = "AUTHORISED")]
         Authorised,
-        [EnumMember(Value = "DELETED")]
-        Deleted
+        [EnumMember(Value = "PAID")]
+        Paid,
+        [EnumMember(Value = "VOIDED")]
+        Voided
     }
 }


### PR DESCRIPTION
According to Xero online document, there are three types of statuses for Prepayment API.
http://developer.xero.com/documentation/api/types/#PrepaymentStatuses
* AUTHORISED
* PAID
* VOIDED

However, enum PrepaymentStatus in Xero-Net has got only two statuses as below.
```C#
    public enum PrepaymentStatus
    {
        [EnumMember(Value = "AUTHORISED")]
        Authorised,
        [EnumMember(Value = "DELETED")]
        Deleted
    }
```
Therefore, VOIDED status goes to Authorised (Default enum value) as there is no matched status.

This should be like this.
```C#
    public enum PrepaymentStatus
    {
        [EnumMember(Value = "AUTHORISED")]
        Authorised,
        [EnumMember(Value = "PAID")]
        Paid,
        [EnumMember(Value = "VOIDED")]
        Voided
    }
```
I have already checked it with the following test code and it works fine.
I can see all the statuses with this change as expected.
```C#
            var prepayments = _api.Prepayments.Find().ToList();
            foreach (var prepayment in prepayments)
            {
                Console.WriteLine("Id:" + prepayment.Id);
                Console.WriteLine("Date:" + prepayment.Date);
                Console.WriteLine("Total:" + prepayment.Total);
                Console.WriteLine("Status:" + prepayment.Status);
                Console.WriteLine("Type:" + prepayment.Type);
            }
```

Thanks.