### PR TITLE
Added a parameter to the PartnerMVCAuthenticator for the signing certpassword as it can be created with one. The parameter defaults to an empty string to prevent a breaking change

### DIFF
--- a/CoreTests/App.config
+++ b/CoreTests/App.config
@@ -11,6 +11,7 @@
     <add key="ConsumerSecret" value="6FJIDKHKKMTNOMR8EVYGKXYIXXXXXX"/>
     <add key="CallbackUrl" value="localhost"/>
     <add key="SigningCertificate" value="..\..\resources\cert\public_privatekey.pfx"/>
+    <add key="SigningCertificatePassword" value=""/>
     <add key="PartnerCertificate" value="skiesareblue"/>
     <add key="PartnerCertificatePassword" value="rosesarered"/>
   </appSettings>

--- a/PayrollTests.AU/App.config
+++ b/PayrollTests.AU/App.config
@@ -11,6 +11,7 @@
     <add key="ConsumerSecret" value="XXXX6LKHL1K0LW1Y5XQMVWXUGAXXXX"/>
     <add key="CallbackUrl" value="localhost"/>
     <add key="SigningCertificate" value="resources\cert\public_privatekey.pfx"/>
+    <add key="SigningCertificatePassword" value=""/>
     <add key="PartnerCertificate" value="skiesareblue"/>
     <add key="PartnerCertificatePassword" value="rosesarered"/>
   </appSettings>

--- a/PayrollTests.US/App.config
+++ b/PayrollTests.US/App.config
@@ -11,6 +11,7 @@
     <add key="ConsumerSecret" value="XXXX0YOM0XSCBPSGEPOJJX453XXXX"/>
     <add key="CallbackUrl" value="localhost"/>
     <add key="SigningCertificate" value="resources\cert\public_privatekey.pfx"/>
+    <add key="SigningCertificatePassword" value=""/>
     <add key="PartnerCertificate" value="skiesareblue"/>
     <add key="PartnerCertificatePassword" value="rosesarered"/>
   </appSettings>

--- a/Xero.Api.Example.Applications/Partner/AmericanPayroll.cs
+++ b/Xero.Api.Example.Applications/Partner/AmericanPayroll.cs
@@ -19,7 +19,8 @@ namespace Xero.Api.Example.Applications.Partner
                     store,
                     ApplicationSettings.SigningCertificatePath,
                     ApplicationSettings.ParterCertificatePath,
-                    ApplicationSettings.ParterCertificatePassword),
+                    ApplicationSettings.ParterCertificatePassword,
+                    ApplicationSettings.SigningCertificatePassword),
                 new Consumer(
                     ApplicationSettings.Key,
                     ApplicationSettings.Secret),

--- a/Xero.Api.Example.Applications/Partner/AustralianPayroll.cs
+++ b/Xero.Api.Example.Applications/Partner/AustralianPayroll.cs
@@ -19,7 +19,8 @@ namespace Xero.Api.Example.Applications.Partner
                     store,
                     ApplicationSettings.SigningCertificatePath,
                     ApplicationSettings.ParterCertificatePath,
-                    ApplicationSettings.ParterCertificatePassword),
+                    ApplicationSettings.ParterCertificatePassword,
+                    ApplicationSettings.SigningCertificatePassword),
                 new Consumer(
                     ApplicationSettings.Key,
                     ApplicationSettings.Secret),

--- a/Xero.Api.Example.Applications/Partner/Core.cs
+++ b/Xero.Api.Example.Applications/Partner/Core.cs
@@ -20,7 +20,8 @@ namespace Xero.Api.Example.Applications.Partner
                     store,
                     ApplicationSettings.SigningCertificatePath,
                     ApplicationSettings.ParterCertificatePath,
-                    ApplicationSettings.ParterCertificatePassword),
+                    ApplicationSettings.ParterCertificatePassword,
+                    ApplicationSettings.SigningCertificatePassword),
                 new Consumer(
                     ApplicationSettings.Key,
                     ApplicationSettings.Secret),

--- a/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
@@ -16,6 +16,13 @@ namespace Xero.Api.Example.Applications.Partner
         {            
         }
 
+        public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string password)
+            : this(baseUri, authorizeUri, callBackUri, store)
+        {
+            _signingCertificate = new X509Certificate2(signingCertificatePath);
+            _certificate = new X509Certificate2(certificatePath, password);
+        }
+
         public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword, string signingCertPassword = "")
             : this(baseUri, authorizeUri, callBackUri, store)
         {

--- a/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
@@ -16,11 +16,11 @@ namespace Xero.Api.Example.Applications.Partner
         {            
         }
 
-        public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string password)
+        public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword, string signingCertPassword = "")
             : this(baseUri, authorizeUri, callBackUri, store)
         {
-            _signingCertificate = new X509Certificate2(signingCertificatePath);
-            _certificate = new X509Certificate2(certificatePath, password);            
+            _signingCertificate = new X509Certificate2(signingCertificatePath, signingCertPassword, X509KeyStorageFlags.MachineKeySet);
+            _certificate = new X509Certificate2(certificatePath, entrustPassword);            
         }
 
         public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, X509Certificate2 signingCertificate, X509Certificate2 certificate)

--- a/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
@@ -17,13 +17,11 @@ namespace Xero.Api.Example.Applications.Partner
         }
 
         public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string password)
-            : this(baseUri, authorizeUri, callBackUri, store)
+            : this(baseUri, authorizeUri, callBackUri, store, signingCertificatePath, certificatePath, password ,"")
         {
-            _signingCertificate = new X509Certificate2(signingCertificatePath);
-            _certificate = new X509Certificate2(certificatePath, password);
         }
 
-        public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword, string signingCertPassword = "")
+        public PartnerAuthenticator(string baseUri, string authorizeUri, string callBackUri, ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword, string signingCertPassword)
             : this(baseUri, authorizeUri, callBackUri, store)
         {
             _signingCertificate = new X509Certificate2(signingCertificatePath, signingCertPassword, X509KeyStorageFlags.MachineKeySet);

--- a/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
@@ -17,6 +17,15 @@ namespace Xero.Api.Example.Applications.Partner
         {            
         }
 
+        public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri,
+            ITokenStore store, string signingCertificatePath, string certificatePath, string password,
+            IConsumer consumer, ITokenStore requestTokenStore)
+            : this(baseUri, authorizeUri, callBackUri, store, consumer, requestTokenStore)
+        {
+            _signingCertificate = new X509Certificate2(signingCertificatePath);
+            _certificate = new X509Certificate2(certificatePath, password);
+        }
+
         public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 
             ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword,
             IConsumer consumer, ITokenStore requestTokenStore, string signingCertPassword = "")

--- a/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
@@ -18,12 +18,12 @@ namespace Xero.Api.Example.Applications.Partner
         }
 
         public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 
-            ITokenStore store, string signingCertificatePath, string certificatePath, string password,
-            IConsumer consumer, ITokenStore requestTokenStore)
+            ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword,
+            IConsumer consumer, ITokenStore requestTokenStore, string signingCertPassword = "")
             : this(baseUri, authorizeUri, callBackUri, store, consumer, requestTokenStore)
         {
-            _signingCertificate = new X509Certificate2(signingCertificatePath);
-            _certificate = new X509Certificate2(certificatePath, password);            
+            _signingCertificate = new X509Certificate2(signingCertificatePath, signingCertPassword, X509KeyStorageFlags.MachineKeySet);
+            _certificate = new X509Certificate2(certificatePath, entrustPassword);            
         }
 
         public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 

--- a/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
@@ -17,7 +17,7 @@ namespace Xero.Api.Example.Applications.Partner
         {            
         }
 
-        public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri,
+        public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 
             ITokenStore store, string signingCertificatePath, string certificatePath, string password,
             IConsumer consumer, ITokenStore requestTokenStore)
             : this(baseUri, authorizeUri, callBackUri, store, consumer, requestTokenStore)

--- a/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
@@ -20,15 +20,13 @@ namespace Xero.Api.Example.Applications.Partner
         public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 
             ITokenStore store, string signingCertificatePath, string certificatePath, string password,
             IConsumer consumer, ITokenStore requestTokenStore)
-            : this(baseUri, authorizeUri, callBackUri, store, consumer, requestTokenStore)
+            : this(baseUri, authorizeUri, callBackUri, store, signingCertificatePath, certificatePath, password, consumer, requestTokenStore, "")
         {
-            _signingCertificate = new X509Certificate2(signingCertificatePath);
-            _certificate = new X509Certificate2(certificatePath, password);
         }
 
         public PartnerMvcAuthenticator(string baseUri, string authorizeUri, string callBackUri, 
             ITokenStore store, string signingCertificatePath, string certificatePath, string entrustPassword,
-            IConsumer consumer, ITokenStore requestTokenStore, string signingCertPassword = "")
+            IConsumer consumer, ITokenStore requestTokenStore, string signingCertPassword)
             : this(baseUri, authorizeUri, callBackUri, store, consumer, requestTokenStore)
         {
             _signingCertificate = new X509Certificate2(signingCertificatePath, signingCertPassword, X509KeyStorageFlags.MachineKeySet);

--- a/Xero.Api.Example.Applications/Partner/Settings.cs
+++ b/Xero.Api.Example.Applications/Partner/Settings.cs
@@ -34,6 +34,11 @@ namespace Xero.Api.Example.Applications.Partner
             get { return ConfigurationManager.AppSettings["PartnerCertificatePassword"]; }
         }
 
+        public string SigningCertificatePassword
+        {
+            get { return ConfigurationManager.AppSettings["SigningCertificatePassword"]; }
+        }
+
         public string Key
         {
             get { return ConfigurationManager.AppSettings["ConsumerKey"]; }

--- a/Xero.Api.Example.Applications/Private/AmericanPayroll.cs
+++ b/Xero.Api.Example.Applications/Private/AmericanPayroll.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Example.Applications.Private
 
         public AmericanPayroll(bool includeRateLimiter = false) :
             base(ApplicationSettings.Uri,
-                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath),
+                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath, ApplicationSettings.SigningCertificatePassword),
                 new Consumer(ApplicationSettings.Key, ApplicationSettings.Secret),
                 null,
                 Mapper,

--- a/Xero.Api.Example.Applications/Private/AustralianPayroll.cs
+++ b/Xero.Api.Example.Applications/Private/AustralianPayroll.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Example.Applications.Private
 
         public AustralianPayroll(bool includeRateLimiter = false) :
             base(ApplicationSettings.Uri,
-                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath),
+                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath, ApplicationSettings.SigningCertificatePassword),
                 new Consumer(ApplicationSettings.Key, ApplicationSettings.Secret),
                 null,
                 Mapper,

--- a/Xero.Api.Example.Applications/Private/Core.cs
+++ b/Xero.Api.Example.Applications/Private/Core.cs
@@ -12,7 +12,7 @@ namespace Xero.Api.Example.Applications.Private
 
         public Core(bool includeRateLimiter = false) :
             base(ApplicationSettings.Uri,
-                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath),
+                new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath, ApplicationSettings.SigningCertificatePassword),
                 new Consumer(ApplicationSettings.Key, ApplicationSettings.Secret),
                 null,
                 Mapper,

--- a/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
@@ -11,9 +11,9 @@ namespace Xero.Api.Example.Applications.Private
         private readonly X509Certificate2 _certificate;
 
         public PrivateAuthenticator(string certificatePath)
+            :this(certificatePath, "")
         {
-            _certificate = new X509Certificate2();
-            _certificate.Import(certificatePath);
+            
         }
 
         public PrivateAuthenticator(string certificatePath, string certificatePassword = "")

--- a/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
@@ -10,10 +10,10 @@ namespace Xero.Api.Example.Applications.Private
     {
         private readonly X509Certificate2 _certificate;
 
-        public PrivateAuthenticator(string certificatePath)
+        public PrivateAuthenticator(string certificatePath, string certificatePassword = "")
         {
             _certificate = new X509Certificate2();
-            _certificate.Import(certificatePath);
+            _certificate.Import(certificatePath, certificatePassword, X509KeyStorageFlags.MachineKeySet);
         }
 
         public PrivateAuthenticator(X509Certificate2 certificate)

--- a/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
@@ -10,6 +10,12 @@ namespace Xero.Api.Example.Applications.Private
     {
         private readonly X509Certificate2 _certificate;
 
+        public PrivateAuthenticator(string certificatePath)
+        {
+            _certificate = new X509Certificate2();
+            _certificate.Import(certificatePath);
+        }
+
         public PrivateAuthenticator(string certificatePath, string certificatePassword = "")
         {
             _certificate = new X509Certificate2();

--- a/Xero.Api.Example.Applications/Private/Settings.cs
+++ b/Xero.Api.Example.Applications/Private/Settings.cs
@@ -13,6 +13,11 @@ namespace Xero.Api.Example.Applications.Private
         {
             get { return ConfigurationManager.AppSettings["SigningCertificate"]; }
         }
+
+        public string SigningCertificatePassword
+        {
+            get { return ConfigurationManager.AppSettings["SigningCertificatePassword"]; }
+        }
     
         public string Key
         {

--- a/Xero.Api.Example.Counts/App.config
+++ b/Xero.Api.Example.Counts/App.config
@@ -11,6 +11,7 @@
     <add key="ConsumerSecret" value="XXXXBGKXJ07M9N9CNPPBASLDSXXXX"/>
     <add key="CallbackUrl" value="oob"/>
     <add key="SigningCertificate" value="resources\cert\public_privatekey.pfx"/>
+    <add key="SigningCertificatePassword" value=""/>
     <add key="PartnerCertificate" value="skiesareblue"/>
     <add key="PartnerCertificatePassword" value="rosesarered"/>
   </appSettings>

--- a/Xero.Api.Example.Creation/App.config
+++ b/Xero.Api.Example.Creation/App.config
@@ -11,6 +11,7 @@
     <add key="ConsumerSecret" value="XXXXBGKXJ07M9N9CNPPBASLDSQXXXX"/>
     <add key="CallbackUrl" value="oob"/>
     <add key="SigningCertificate" value="resources\cert\public_privatekey.pfx"/>
+    <add key="SigningCertificatePassword" value=""/>
     <add key="PartnerCertificate" value="skiesareblue"/>
     <add key="PartnerCertificatePassword" value="rosesarered"/>
   </appSettings>

--- a/Xero.Api.Example.MVC/Helpers/XeroApiHelper.cs
+++ b/Xero.Api.Example.MVC/Helpers/XeroApiHelper.cs
@@ -30,6 +30,7 @@ namespace Xero.Api.Example.MVC.Helpers
             var basePartnerApiUrl = "https://api-partner.network.xero.com";
 
             var signingCertificatePath = @"C:\Dev\your_public_privatekey.pfx";
+            var signingCertificatePassword = "Your_signing_cert_password - leave empty if you didn't set one when creating the cert";
             var clientCertificatePath = @"C:\Dev\your_entrust_cert.p12";
             var clientCertificatePassword = "your_entrust_cert_password";
 
@@ -55,8 +56,8 @@ namespace Xero.Api.Example.MVC.Helpers
             var partnerConsumer = new Consumer(partnerConsumerKey, partnerConsumerSecret);
 
             var partnerAuthenticator = new PartnerMvcAuthenticator(basePartnerApiUrl, baseApiUrl, callbackUrl,
-                    memoryStore, signingCertificatePath, clientCertificatePath, clientCertificatePassword,
-                    partnerConsumer, requestTokenStore);
+                    memoryStore, signingCertificatePath, clientCertificatePath, clientCertificatePassword, 
+                    partnerConsumer, requestTokenStore, signingCertificatePassword);
 
             var partnerApplicationSettings = new ApplicationSettings
             {


### PR DESCRIPTION
@philals 

resolves https://github.com/XeroAPI/Xero-Net/issues/128