### PR TITLE
Add payments to credit notes

### DIFF
--- a/Xero.Api/Core/Model/CreditNote.cs
+++ b/Xero.Api/Core/Model/CreditNote.cs
@@ -75,5 +75,8 @@ namespace Xero.Api.Core.Model
 
         [DataMember(EmitDefaultValue = false)]
         public List<CreditNoteAllocation> Allocations { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<Payment> Payments { get; set; }
     }
 }

--- a/Xero.Api/Core/Model/Overpayment.cs
+++ b/Xero.Api/Core/Model/Overpayment.cs
@@ -54,5 +54,8 @@ namespace Xero.Api.Core.Model
 
         [DataMember(EmitDefaultValue = false)]
         public List<OverpaymentAllocation> Allocations { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<Payment> Payments { get; set; }
     }
 }

--- a/Xero.Api/Core/Model/Prepayment.cs
+++ b/Xero.Api/Core/Model/Prepayment.cs
@@ -54,5 +54,8 @@ namespace Xero.Api.Core.Model
 
         [DataMember(EmitDefaultValue = false)]
         public List<PrepaymentAllocation> Allocations { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<Payment> Payments { get; set; }
     }
 }


### PR DESCRIPTION
When cash refunds are made to credit notes, the API returns them as Payments in the restful interface. I have added the property to credit notes and they are loaded in automatically when they are present.