### PR TITLE
Corrected Readme Typo which was redirecting to dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿Xero-Net
+Xero-Net
 ========
 [![xero-api-sdk MyGet Build Status](https://www.myget.org/BuildSource/Badge/xero-api-sdk?identifier=045754d8-de3f-4f0c-960a-ae6e16608e24)](https://www.myget.org/)
 
@@ -188,7 +188,7 @@ The examples are
 
 ##Serialization
 
-All communication with the [Xero API](http://deverloper.xero.com) is compressed at source. Writing to the API is done with XML. The data model classes have be attributed to give a small XML payload. All communication back from the API is JSON. These details are transparent to the user of the class library.
+All communication with the [Xero API](http://developer.xero.com) is compressed at source. Writing to the API is done with XML. The data model classes have be attributed to give a small XML payload. All communication back from the API is JSON. These details are transparent to the user of the class library.
 
 ##Usage
 To get going quickly:


### PR DESCRIPTION
Corrected Readme Typo which was redirecting to dead link `http://deverloper.xero.com` instead of `http://developer.xero.com`