### PR TITLE
Add BankAmount property to Payment

### DIFF
--- a/Xero.Api/Core/Model/Payment.cs
+++ b/Xero.Api/Core/Model/Payment.cs
@@ -25,6 +25,9 @@ namespace Xero.Api.Core.Model
         public decimal CurrencyRate { get; set; }
 
         [DataMember]
+        public decimal BankAmount { get; set; }
+
+        [DataMember]
         public decimal Amount { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
Last year, BankAmount was added to Payments endpoint according to the release note below.
http://developer.xero.com/documentation/api/v2-release-notes/#2.130

I would like to use this but unfortunately in Xero-Net, we do not have such property at the moment.
I suppose it was just missed updating Xero-Net at the time of the release above.

I added it and tested on my local environment. It worked fine.
Please accept my pull request.