### PR TITLE
Check for null ValidationErrors on ApiException parsing

### DIFF
--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Integration\Attachments\Attachments.cs" />
     <Compile Include="Integration\General\Errors.cs" />
     <Compile Include="Integration\TaxRates\Create.cs" />
+    <Compile Include="Unit\ExceptionTests.cs" />
     <Compile Include="Unit\RateLimiterTest.cs" />
     <Compile Include="Unit\SummarizeErrors.cs" />
     <Compile Include="Unit\UrlEncoder.cs" />

--- a/CoreTests/Unit/ExceptionTests.cs
+++ b/CoreTests/Unit/ExceptionTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xero.Api.Infrastructure.Exceptions;
+using Xero.Api.Infrastructure.Model;
+
+namespace CoreTests.Unit
+{
+    [TestFixture]
+    public class ExceptionTests
+    {
+        [Test]
+        public void ManageNullValidationErrorsInApiException()
+        {
+            var validationException = new ValidationException(ApiException);
+            Assert.That(validationException.ValidationErrors, Has.Count.EqualTo(5));
+        }
+
+        private ApiException ApiException
+        {
+            get
+            {
+                return new ApiException
+                {
+                    Elements = new List<DataContractBase>
+                    {
+                        new DataContractBase
+                        {
+                            ValidationErrors = new List<ValidationError>
+                            {
+                                new ValidationError {Message = "Validation Error 1"}
+                            }
+                        },
+                        new DataContractBase
+                        {
+                            ValidationErrors = new List<ValidationError>
+                            {
+                                new ValidationError {Message = "Validation Error 2"}
+                            }
+                        },
+                        new DataContractBase
+                        {
+                            ValidationErrors = new List<ValidationError>
+                            {
+                                new ValidationError {Message = "Validation Error 3"}
+                            }
+                        },
+                        new DataContractBase
+                        {
+                            ValidationErrors = new List<ValidationError>
+                            {
+                                new ValidationError {Message = "Validation Error 4"}
+                            }
+                        },
+                        new DataContractBase
+                        {
+                            ValidationErrors = new List<ValidationError>
+                            {
+                                new ValidationError {Message = "Validation Error 5"}
+                            }
+                        },
+                        new DataContractBase
+                        {
+                            ValidationErrors = null // this is a valid data condition for large responses
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/Xero.Api/Infrastructure/Exceptions/ValidationException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/ValidationException.cs
@@ -15,6 +15,7 @@ namespace Xero.Api.Infrastructure.Exceptions
                 ValidationErrors = new List<ValidationError>();
                 foreach (var ve in apiException
                     .Elements
+                    .Where(x => x.ValidationErrors != null)
                     .SelectMany(e => e.ValidationErrors))
                 {
                     ValidationErrors.Add(ve);


### PR DESCRIPTION
I hit a condition today where the API was returning an ApiException that had multiple DataContractBase instances with ValidationErrors.  One of the DataContractBase instances had a 'null' ValidationErrors collection (for some reason, possibly due to a large response?), generating an unhandled exception in the ApiException constructor.

This is a test + fix to ensure the condition is guarded.