### PR TITLE
Changed account number, BSB and ABN to type string.

### DIFF
--- a/PayrollTests.AU/Integration/Employees/Create.cs
+++ b/PayrollTests.AU/Integration/Employees/Create.cs
@@ -30,7 +30,7 @@ namespace PayrollTests.AU.Integration.Employees
                         {
                             AccountName = "Cheque",
                             AccountNumber = "645645645",
-                            BankStateBranch = 121232,
+                            BankStateBranch = "021232",
                             Remainder = true,
                             StatementText = "Salary"
                         }

--- a/PayrollTests.AU/Integration/Employees/EmployeesTest.cs
+++ b/PayrollTests.AU/Integration/Employees/EmployeesTest.cs
@@ -60,7 +60,7 @@ namespace PayrollTests.AU.Integration.Employees
                 return Api.Create(new SuperFund
                 {
                     Type = SuperfundType.Regulated,
-                    Abn = 78984178687,
+                    Abn = "78984178687",
                 }).Id;
             }
         }

--- a/PayrollTests.AU/Integration/SuperFunds/Create.cs
+++ b/PayrollTests.AU/Integration/SuperFunds/Create.cs
@@ -17,7 +17,7 @@ namespace PayrollTests.AU.Integration.SuperFunds
             var sf = Api.Create(new SuperFund
             {
                 Type = SuperfundType.Regulated,
-                Abn = 78984178687,
+                Abn = "08984178687",
             });
 
             Assert.IsTrue(sf.Id != Guid.Empty);

--- a/PayrollTests.AU/Integration/SuperFunds/Update.cs
+++ b/PayrollTests.AU/Integration/SuperFunds/Update.cs
@@ -14,11 +14,11 @@ namespace PayrollTests.AU.Integration.SuperFunds
             var sf = Api.Create(new SuperFund
             {
                 Type = SuperfundType.SelfManaged,
-                Abn = 11001032511,
+                Abn = "01001032511",
                 Name = "Clive Monk Superannuation Fund",
-                BankStateBranch = 159357,
+                BankStateBranch = "159357",
                 AccountName = "Clive Monk Superannuation Fund",
-                AccountNumber = 111222333,
+                AccountNumber = "111222333",
             });
 
 
@@ -26,11 +26,11 @@ namespace PayrollTests.AU.Integration.SuperFunds
             {
                 Id = sf.Id,
                 Type = SuperfundType.SelfManaged,
-                Abn = 11001032511,
+                Abn = "11001032511",
                 Name = "Clive Superannuation Fund",
-                BankStateBranch = 159357,
+                BankStateBranch = "059357",
                 AccountName = "Test",
-                AccountNumber = 654645645,
+                AccountNumber = "654645645",
             });
 
         }

--- a/Xero.Api/Payroll/Australia/Model/BankAccount.cs
+++ b/Xero.Api/Payroll/Australia/Model/BankAccount.cs
@@ -12,7 +12,7 @@ namespace Xero.Api.Payroll.Australia.Model
         public string AccountName { get; set; }
 
         [DataMember(Name = "BSB")]
-        public int BankStateBranch { get; set; }
+        public string BankStateBranch { get; set; }
 
         [DataMember]
         public string AccountNumber { get; set; }

--- a/Xero.Api/Payroll/Australia/Model/SuperFund.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperFund.cs
@@ -13,7 +13,7 @@ namespace Xero.Api.Payroll.Australia.Model
         
         [DataMember(Name = "ABN")]
         // Australian Business Number
-        public long Abn { get; set; }
+        public string Abn { get; set; }
 
         [DataMember(Name = "SPIN")]
         // Superannuation Product Identification Number 
@@ -30,13 +30,13 @@ namespace Xero.Api.Payroll.Australia.Model
         public string AccountName { get; set; }
 
         [DataMember]
-        public long AccountNumber { get; set; }
+        public string AccountNumber { get; set; }
         
         [DataMember(Name ="BSB")]
-        public int BankStateBranch { get; set; }
+        public string BankStateBranch { get; set; }
 
         [DataMember]
-        public long EmployerNumber { get; set; }
+        public string EmployerNumber { get; set; }
         
         [DataMember]
         public string  ElectronicServiceAddress { get; set; }

--- a/Xero.Api/Payroll/Australia/Model/SuperFundProduct.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperFundProduct.cs
@@ -8,7 +8,7 @@ namespace Xero.Api.Payroll.Australia.Model
     {
         [DataMember(Name = "ABN")]
         // Australian Business Number
-        public long Abn { get; set; }
+        public string Abn { get; set; }
 
         [DataMember(Name = "SPIN")]
         // Superannuation Product Identification Number 


### PR DESCRIPTION
There are several banks in Australia and New Zealand which have a 0 at the
front of their BSB numbers eg Commonwealth Bank. With the type as an
integer it drops the leading 0 which gives a validation error when sent to
the server as the BSB is too short.

The first two digits of an ABN number is a checksum which can also contain
a zero.

You're not going to add a bank account to another bank account number and
divide it by their BSB and times it by their ABN.
Rule of thumb: If you not doing arithmetic with the numbers, store them as
a string.