### PR TITLE
Make SubTotal, Total and TotalTax consistent types

### DIFF
--- a/Xero.Api/Core/Model/CreditNote.cs
+++ b/Xero.Api/Core/Model/CreditNote.cs
@@ -38,10 +38,10 @@ namespace Xero.Api.Core.Model
         public Contact Contact { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public DateTime DueDate { get; set; }
+        public DateTime? DueDate { get; set; }
 
         [DataMember(Name = "BrandingThemeID", EmitDefaultValue = false)]
         public Guid BrandingThemeId { get; set; }
@@ -53,13 +53,13 @@ namespace Xero.Api.Core.Model
         public LineAmountType LineAmountTypes { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal SubTotal { get; set; }
+        public decimal? SubTotal { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal TotalTax { get; set; }
+        public decimal? TotalTax { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal Total { get; set; }
+        public decimal? Total { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public string CurrencyCode { get; set; }

--- a/Xero.Api/Core/Model/Receipt.cs
+++ b/Xero.Api/Core/Model/Receipt.cs
@@ -32,13 +32,13 @@ namespace Xero.Api.Core.Model
         public LineAmountType LineAmountTypes { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal SubTotal { get; set; }
+        public decimal? SubTotal { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal TotalTax { get; set; }
+        public decimal? TotalTax { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public decimal Total { get; set; }
+        public decimal? Total { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public ReceiptStatus Status { get; set; }


### PR DESCRIPTION
While we're on the subject of breaking changes, these are to make some of the objects more consistent with each other. For example, some of the fields are nullable on Invoice, but not on CreditNote etc