### PR TITLE
Set up correct mapping of PO fields with JSON response

### DIFF
--- a/Xero.Api/Core/Model/PurchaseOrder.cs
+++ b/Xero.Api/Core/Model/PurchaseOrder.cs
@@ -28,10 +28,10 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public string DeliveryAddress { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(Name = "DeliveryAttentionTo", EmitDefaultValue = false)]
         public string AttentionTo { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(Name = "DeliveryPhone", EmitDefaultValue = false)]
         public string Telephone { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
#163 
Fields of the PurchaseOrder class and in JSON response have different names so they cannot be automatically mapped. Added "Name" attribute with correct naming to the fields.