### PR TITLE
Reveal details of successful elements even when some failed

### DIFF
--- a/Xero.Api/Infrastructure/Exceptions/BadRequestException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/BadRequestException.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using Xero.Api.Infrastructure.Model;
 
 namespace Xero.Api.Infrastructure.Exceptions
@@ -10,10 +11,12 @@ namespace Xero.Api.Infrastructure.Exceptions
             : base(HttpStatusCode.BadRequest, apiException.Message)
         {
             ErrorNumber = apiException.ErrorNumber;
-            Type = apiException.Type;            
+            Type = apiException.Type;
+            Elements = apiException.Elements;     
         }
 
         public int ErrorNumber { get; private set; }
-        public string Type { get; private set; }        
+        public string Type { get; private set; }
+        public ICollection<DataContractBase> Elements { get; private set; }
     }
 }


### PR DESCRIPTION
If you submit 20 transactions in a batch but only a couple fail you only get the details back of the couple that failed. This change makes the data available as part of the exception.