### PR TITLE
Allow SummariseErrors to be set at the API level for all entities

### DIFF
--- a/Xero.Api/Core/IXeroCoreApi.cs
+++ b/Xero.Api/Core/IXeroCoreApi.cs
@@ -84,5 +84,7 @@ namespace Xero.Api.Core
         TaxRate Update(TaxRate item);
         ImportSummary Update(Setup item);
         TrackingCategory Update(TrackingCategory item);
+
+        void SummarizeErrors(bool summarize);
     }
 }

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -344,6 +344,29 @@ namespace Xero.Api.Core
         {
             return TrackingCategories.Update(item);
         }
-        
+
+        public void SummarizeErrors(bool summarize)
+        {
+            Accounts.SummarizeErrors(summarize);
+            BankTransactions.SummarizeErrors(summarize);
+            BankTransfers.SummarizeErrors(summarize);
+            Contacts.SummarizeErrors(summarize);
+            ContactGroups.SummarizeErrors(summarize);
+            CreditNotes.SummarizeErrors(summarize);
+            Employees.SummarizeErrors(summarize);
+            Employees.SummarizeErrors(summarize);
+            Files.SummarizeErrors(summarize);
+            Folders.SummarizeErrors(summarize);
+            Inbox.SummarizeErrors(summarize);
+            Invoices.SummarizeErrors(summarize);
+            Items.SummarizeErrors(summarize);
+            LinkedTransactions.SummarizeErrors(summarize);
+            ManualJournals.SummarizeErrors(summarize);
+            Payments.SummarizeErrors(summarize);
+            PurchaseOrders.SummarizeErrors(summarize);
+            Receipts.SummarizeErrors(summarize);
+            TaxRates.SummarizeErrors(summarize);
+            TrackingCategories.SummarizeErrors(summarize);
+        }
     }
 }


### PR DESCRIPTION
Rather than set this for each object type whenever we use it, we'd rather be able to set it once per instance of the endpoint we create