### PR TITLE
Have LineItemId serialize out to LineItemID

### DIFF
--- a/Xero.Api/Core/Model/LineItem.cs
+++ b/Xero.Api/Core/Model/LineItem.cs
@@ -37,7 +37,7 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false, Name = "Tracking")]
         public ItemTracking Tracking { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(EmitDefaultValue = false, Name = "LineItemID")]
         public Guid LineItemId { get; set; }
     }
 }


### PR DESCRIPTION
The API expects LineItemID. This makes it so it will serialize correctly

@philals 