### PR TITLE
Persist SummarizeErrors settings

### DIFF
--- a/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/Base/XeroCreateEndpoint.cs
@@ -30,10 +30,22 @@ namespace Xero.Api.Core.Endpoints.Base
             return Create(new[] { item }).First();
         }
 
+        bool? summarizeErrors;
+
         public IXeroCreateEndpoint<T, TResult, TRequest, TResponse> SummarizeErrors(bool summarize)
         {
             AddParameter("summarizeErrors", summarize);
+            summarizeErrors = summarize;
             return this;
+        }
+
+        public override void ClearQueryString()
+        {
+            base.ClearQueryString();
+            if (summarizeErrors.HasValue)
+            {
+                AddParameter("summarizeErrors", summarizeErrors.Value);
+            }
         }
 
         protected IEnumerable<TResult> Put(TRequest data)


### PR DESCRIPTION
When issuing multiple create requests, it makes sense to persist the SummarizeError setting rather than set it each time (especially with the previous change to mean you can set it once and apply it for all endpoints)