### PR TITLE
Add parameterless constructor to exceptions

### DIFF
--- a/Xero.Api/Infrastructure/Exceptions/BadRequestException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/BadRequestException.cs
@@ -1,11 +1,15 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using Xero.Api.Infrastructure.Model;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class BadRequestException
         : XeroApiException
     {
+        public BadRequestException() { }
+
         public BadRequestException(ApiException apiException)
             : base(HttpStatusCode.BadRequest, apiException.Message)
         {

--- a/Xero.Api/Infrastructure/Exceptions/NotAvailableException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/NotAvailableException.cs
@@ -1,10 +1,14 @@
+using System;
 using System.Net;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     internal class NotAvailableException
         : XeroApiException
     {
+        public NotAvailableException() { }
+
         public NotAvailableException(string body)
             : base(HttpStatusCode.ServiceUnavailable, body)
         {            

--- a/Xero.Api/Infrastructure/Exceptions/NotFoundException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/NotFoundException.cs
@@ -1,10 +1,14 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class NotFoundException
         : XeroApiException
     {
+        public NotFoundException() { }
+
         public NotFoundException(string body)
             : base(HttpStatusCode.NotFound, body)
         {

--- a/Xero.Api/Infrastructure/Exceptions/RateExceededException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/RateExceededException.cs
@@ -1,10 +1,14 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class RateExceededException
         : XeroApiException
     {
+        public RateExceededException() { }
+
         public RateExceededException(string message) : base(HttpStatusCode.ServiceUnavailable, message)
         {            
         }

--- a/Xero.Api/Infrastructure/Exceptions/UnauthorizedException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/UnauthorizedException.cs
@@ -1,10 +1,14 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class UnauthorizedException
         : XeroApiException
     {
+        public UnauthorizedException() { }
+
         public UnauthorizedException(string body)
             : base(HttpStatusCode.Unauthorized, body)
         {

--- a/Xero.Api/Infrastructure/Exceptions/ValidationException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/ValidationException.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xero.Api.Infrastructure.Model;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class ValidationException
         : BadRequestException
     {
+        public ValidationException() { }
+
         public ValidationException(ApiException apiException)
             : base(apiException)
         {

--- a/Xero.Api/Infrastructure/Exceptions/XeroApiException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/XeroApiException.cs
@@ -3,9 +3,12 @@ using System.Net;
 
 namespace Xero.Api.Infrastructure.Exceptions
 {
+    [Serializable]
     public class XeroApiException
         : Exception
     {
+        public XeroApiException() { }
+
         public XeroApiException(HttpStatusCode statusCode, string body)
             : base(body)
         {


### PR DESCRIPTION
There are a few parameters that it's useful to have on exceptions when creating them. As a start, I've added a parameterless constructor for them all.

This will allow us to use them in our mocking library as it allows exceptions with parameterless constructors to be used in a generic fashion.