### PR TITLE
Set timeout to 5 minutes to cater for slow requests

### DIFF
--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -14,6 +14,8 @@ namespace Xero.Api.Infrastructure.Http
     // It uses IAuthenticator or ICertificateAuthenticator to do the signing
     internal class HttpClient
     {
+        static readonly int defaultTimeout = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
+
         private readonly string _baseUri;
         private readonly IAuthenticator _auth;
         private readonly IRateLimiter _rateLimiter;
@@ -171,6 +173,8 @@ namespace Xero.Api.Infrastructure.Http
             }
 
             var request = (HttpWebRequest)WebRequest.Create(uri.Uri);
+
+            request.Timeout = defaultTimeout;
 
             request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
             


### PR DESCRIPTION
Our understanding is that the API has a timeout of 200 seconds. The [default](https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest.timeout) is 100 seconds. We'd like this to be set to a larger number (300 seconds) so that we can be sure that no processing is still ongoing (as we've previously had issues where a request has "timed out" but the results have actually been saved in the API