### PR TITLE
Do not return expired access tokens in the MVC example authenticators

### DIFF
--- a/Xero.Api.Example.Applications/Public/PublicMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Public/PublicMvcAuthenticator.cs
@@ -51,7 +51,12 @@ namespace Xero.Api.Example.Applications.Public
         {
             var existingAccessToken = Store.Find(userId);
             if (existingAccessToken != null)
-                return existingAccessToken;
+            {
+                if (!existingAccessToken.HasExpired)
+                    return existingAccessToken;
+                else
+                    Store.Delete(existingAccessToken);
+            }
 
             var requestToken = _requestTokenStore.Find(userId);
             if (requestToken == null)


### PR DESCRIPTION
Clone of #203 