### PR TITLE
Payroll Fixes

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/DeductionLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/DeductionLine.cs
@@ -13,8 +13,9 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(EmitDefaultValue = false)]
         public decimal? Amount { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(EmitDefaultValue = true)]
         public DeductionCalculationType CalculationType { get; set; }
+
 
         [DataMember(EmitDefaultValue = false)]
         public decimal NumberOfUnits { get; set; }

--- a/Xero.Api/Payroll/Australia/Model/EarningsLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/EarningsLine.cs
@@ -30,5 +30,8 @@ namespace Xero.Api.Payroll.Australia.Model
 
         [DataMember(EmitDefaultValue = false)]
         public EarningsRateCalculationType EarningsRateCalculation { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public EarningsRateCalculationType CalculationType { get; set; }
     } 
 }

--- a/Xero.Api/Payroll/Australia/Model/LeaveLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/LeaveLine.cs
@@ -10,7 +10,7 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(Name = "LeaveTypeID")]
         public Guid LeaveTypeId { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(EmitDefaultValue = true)]
         public decimal NumberOfUnits { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/Xero.Api/Payroll/Australia/Model/Payslip.cs
+++ b/Xero.Api/Payroll/Australia/Model/Payslip.cs
@@ -24,7 +24,7 @@ namespace Xero.Api.Payroll.Australia.Model
         public decimal Wages { get; set; }
 
         [DataMember]
-        public List<EarningsLine> EarningsLines { get; set; }
+        public List<PayslipEarningsLine> EarningsLines { get; set; }
 
         [DataMember]
         public List<DeductionLine> DeductionLines { get; set; }

--- a/Xero.Api/Payroll/Australia/Model/Payslip.cs
+++ b/Xero.Api/Payroll/Australia/Model/Payslip.cs
@@ -46,5 +46,9 @@ namespace Xero.Api.Payroll.Australia.Model
 
         [DataMember]
         public List<TaxLine> TaxLines { get; set; }
+
+        [DataMember(EmitDefaultValue = false, Name = "PayRunID")]
+        public Guid PayRunId { get; set; }
+
     }
 }

--- a/Xero.Api/Payroll/Australia/Model/PayslipEarningsLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/PayslipEarningsLine.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Xero.Api.Payroll.Australia.Model
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Earnings Line for a payslip
+    /// </summary>
+    [DataContract(Namespace = "", Name = "EarningsLine")]
+    public class PayslipEarningsLine
+    {
+        [DataMember(Name = "EarningsRateID")]
+        public Guid EarningsRateId { get; set; }
+
+        [DataMember()]
+        public decimal? RatePerUnit { get; set; }
+
+        [DataMember()]
+        public decimal? NumberOfUnits { get; set; }
+
+        [DataMember(EmitDefaultValue = true)]
+        public decimal? FixedAmount { get; set; }
+    }
+}

--- a/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
@@ -7,7 +7,7 @@ namespace Xero.Api.Payroll.Australia.Model
     [DataContract(Namespace = "")]
     public class SuperannuationLine
     {
-        [DataMember(Name = "SuperMembershipID")]
+        [DataMember(Name = "SuperMembershipID", EmitDefaultValue = false)]
         public Guid SuperMembershipId { get; set; }
 
         [DataMember]

--- a/Xero.Api/Payroll/Australia/Model/TaxDeclaration.cs
+++ b/Xero.Api/Payroll/Australia/Model/TaxDeclaration.cs
@@ -23,7 +23,7 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(EmitDefaultValue = false)]
         public bool AustralianResidentForTaxPurposes { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(EmitDefaultValue = true)]
         public bool TaxFreeThresholdClaimed { get; set; }
 
         [DataMember(Name = "HasHELPDebt", EmitDefaultValue = false)]
@@ -31,7 +31,7 @@ namespace Xero.Api.Payroll.Australia.Model
 
         [DataMember(Name = "HasSFSSDebt", EmitDefaultValue = false)]
         public bool HasStudentFinancialSupplementSchemeDebt { get; set; }
-        
+
         [DataMember(Name = "HasTSLDebt", EmitDefaultValue = false)]
         public bool HasTradeSupportLoan { get; set; }
 
@@ -51,5 +51,9 @@ namespace Xero.Api.Payroll.Australia.Model
 
         [DataMember(EmitDefaultValue = false)]
         public decimal? UpwardVariationTaxWithholdingAmount { get; set; }
+
+
+        [DataMember(Name = "TFNExemptionType", EmitDefaultValue = false)]
+        public TaxFileNumberExemptionType TaxFileNumberExemption { get; set; }
     }
 }

--- a/Xero.Api/Payroll/Australia/Model/Types/SuperannuationCalculationType.cs
+++ b/Xero.Api/Payroll/Australia/Model/Types/SuperannuationCalculationType.cs
@@ -5,6 +5,8 @@ namespace Xero.Api.Payroll.Australia.Model.Types
     [DataContract(Namespace = "")]
     public enum SuperannuationCalculationType
     {
+        [EnumMember(Value = "STATUTORY")]
+        Statutory,
         [EnumMember(Value = "FIXEDAMOUNT")]
         FixedAmount,
         [EnumMember(Value = "PERCENTAGEOFEARNINGS")]

--- a/Xero.Api/Payroll/Australia/Model/Types/TaxFileNumberExemptionType.cs
+++ b/Xero.Api/Payroll/Australia/Model/Types/TaxFileNumberExemptionType.cs
@@ -5,6 +5,8 @@ namespace Xero.Api.Payroll.Australia.Model.Types
     [DataContract(Namespace = "", Name = "TFNExemptionType")]
     public enum TaxFileNumberExemptionType
     {
+        [EnumMember(Value = "QUOTED")]
+        Quoted,
         [EnumMember(Value = "NOTQUOTED")]
         NotQuoted,
         [EnumMember(Value = "PENDING")]

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Payroll\America\Response\TimesheetsResponse.cs" />
     <Compile Include="Payroll\Australia\Endpoints\TimesheetsEndpoint.cs" />
     <Compile Include="Payroll\Australia\Model\LeaveBalance.cs" />
+    <Compile Include="Payroll\Australia\Model\PayslipEarningsLine.cs" />
     <Compile Include="Payroll\Australia\Model\Settings.cs" />
     <Compile Include="Payroll\Australia\Model\Timesheet.cs" />
     <Compile Include="Payroll\Australia\Model\TimesheetLine.cs" />


### PR DESCRIPTION
I've included several fixes (mainly emitting default values) to adhere to Xero API validation. These changes affect:
- Tax Declarations (TaxFreeThresholdClaimed)
- Superannuations (SuperMemershipId)
- Payslip (added Pay Run Id)
- LeaveLine (now emits NumberOfUnits on default)
- EarningsLine (Added CalculationType as it's required)
- DeducationLine (CalculationType now emits default value as it's required)
- SuperannuationCalculationType now include "Statutory" type
