### PR TITLE
Adds into the EXAMPLEs how to use Payroll with Scopes and Public apps…

### DIFF
--- a/Xero.Api.Example.Applications/Public/AustralianPayroll.cs
+++ b/Xero.Api.Example.Applications/Public/AustralianPayroll.cs
@@ -10,13 +10,13 @@ namespace Xero.Api.Example.Applications.Public
         private static readonly DefaultMapper Mapper = new DefaultMapper();
         private static readonly Settings ApplicationSettings = new Settings();
 
-        public AustralianPayroll(ITokenStore store, IUser user, bool includeRateLimiter = false) :
+        public AustralianPayroll(ITokenStore store, IUser user, bool includeRateLimiter = false, string scope = null) :
             base(ApplicationSettings.Uri,
                 new PublicAuthenticator(
                     ApplicationSettings.Uri,
                     ApplicationSettings.Uri,
                     ApplicationSettings.CallBackUri,
-                    store),
+                    store, scope),
                 new Consumer(
                     ApplicationSettings.Key,
                     ApplicationSettings.Secret),

--- a/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
@@ -7,14 +7,17 @@ namespace Xero.Api.Example.Applications.Public
 {
     public class PublicAuthenticator : TokenStoreAuthenticator
     {
-        public PublicAuthenticator(string baseUri, string tokenUri, string callBackUrl, ITokenStore store) 
+        private readonly string _scope;
+
+        public PublicAuthenticator(string baseUri, string tokenUri, string callBackUrl, ITokenStore store, string scope = null) 
             : base(baseUri, tokenUri, callBackUrl, store)
-        {            
+        {
+            _scope = scope;
         }
 
         protected override string AuthorizeUser(IToken token)
         {
-            var authorizeUrl = GetAuthorizeUrl(token);
+            var authorizeUrl = GetAuthorizeUrl(token, _scope);
 
             Process.Start(authorizeUrl);
 

--- a/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
+++ b/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
@@ -97,11 +97,11 @@ namespace Xero.Api.Example.Applications
                 GetAuthorization(requestToken, "POST", Tokens.AccessUri, null, verifier));
         }
 
-        protected string GetAuthorizeUrl(IToken token)
+        protected string GetAuthorizeUrl(IToken token, string scope = null)
         {
             return new UriBuilder(Tokens.AuthorizeUri)
             {
-                Query = "oauth_token=" + token.TokenKey
+                Query = "oauth_token=" + token.TokenKey + "&scope=" + scope
             }.Uri.ToString();
         }
 


### PR DESCRIPTION
…. To use change one of the example applications to have this line "var _api = new AustralianPayroll(tokenStore, user, false, "payroll.employees,payroll.payitems")"