### PR TITLE
Add support for application/x-www-form-urlencoded PUTs and POSTs

### DIFF
--- a/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using Xero.Api.Infrastructure.Interfaces;
@@ -46,9 +47,9 @@ namespace Xero.Api.Example.Applications.Partner
         }
 
         protected override string CreateSignature(IToken token, string verb, Uri uri,
-            string verifier, bool renewToken = false, string callback = null)
+            string verifier, bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
-            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier, renewToken, callback);
+            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier, renewToken, callback, additionalParameters);
         }
 
         protected override IToken RenewToken(IToken sessionToken, IConsumer consumer)

--- a/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Partner/PartnerMvcAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Xero.Api.Example.Applications.Public;
 using Xero.Api.Infrastructure.Interfaces;
@@ -39,9 +40,9 @@ namespace Xero.Api.Example.Applications.Partner
         }
 
         protected override string CreateSignature(IToken token, string verb, Uri uri,
-            string verifier, bool renewToken = false, string callback = null)
+            string verifier, bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
-            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier, renewToken, callback);
+            return new RsaSha1Signer().CreateSignature(_signingCertificate, token, uri, verb, verifier, renewToken, callback, additionalParameters);
         }
 
         protected override IToken RenewToken(IToken sessionToken, IConsumer consumer)

--- a/Xero.Api.Example.Applications/Private/Core.cs
+++ b/Xero.Api.Example.Applications/Private/Core.cs
@@ -10,14 +10,15 @@ namespace Xero.Api.Example.Applications.Private
         private static readonly DefaultMapper Mapper = new DefaultMapper();
         private static readonly Settings ApplicationSettings = new Settings();
 
-        public Core(bool includeRateLimiter = false) :
+        public Core(bool includeRateLimiter = false, bool useFormUrlEncodedPutsAndPosts = false) :
             base(ApplicationSettings.Uri,
                 new PrivateAuthenticator(ApplicationSettings.SigningCertificatePath, ApplicationSettings.SigningCertificatePassword),
                 new Consumer(ApplicationSettings.Key, ApplicationSettings.Secret),
                 null,
                 Mapper,
                 Mapper,
-                includeRateLimiter ? new RateLimiter() : null)
+                includeRateLimiter ? new RateLimiter() : null,
+                useFormUrlEncodedPutsAndPosts)
         {
         }
     }

--- a/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth;
@@ -27,7 +28,7 @@ namespace Xero.Api.Example.Applications.Private
             _certificate = certificate;
         }
 
-        public string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1)
+        public string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
             var token = new Token
             {
@@ -36,7 +37,7 @@ namespace Xero.Api.Example.Applications.Private
                 TokenKey = consumer.ConsumerKey
             };
 
-            return new RsaSha1Signer().CreateSignature(_certificate, token, uri, verb);
+            return new RsaSha1Signer().CreateSignature(_certificate, token, uri, verb, additionalParameters: additionalParameters);
         }
 
         public X509Certificate Certificate { get { return _certificate; } }

--- a/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Public/PublicAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth.Signing;
@@ -27,9 +28,9 @@ namespace Xero.Api.Example.Applications.Public
         }
 
         protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier,
-            bool renewToken = false, string callback = null)
+            bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
-            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier, callback);
+            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier, callback, additionalParameters);
         }
 
         protected override IToken RenewToken(IToken sessionToken, IConsumer consumer)

--- a/Xero.Api.Example.Applications/Public/PublicMvcAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Public/PublicMvcAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth.Signing;
 
@@ -23,9 +24,9 @@ namespace Xero.Api.Example.Applications.Public
         }
 
         protected override string CreateSignature(IToken token, string verb, Uri uri, string verifier,
-            bool renewToken = false, string callback = null)
+            bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
-            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier, callback);
+            return new HmacSha1Signer().CreateSignature(token, uri, verb, verifier, callback, additionalParameters);
         }
 
         protected override IToken RenewToken(IToken sessionToken, IConsumer consumer)

--- a/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
+++ b/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth;
 
@@ -34,9 +35,9 @@ namespace Xero.Api.Example.Applications
             Store = store;                      
         }
 
-        public string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1)
+        public string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
-            return GetAuthorization(GetToken(consumer, user), verb, uri.AbsolutePath, uri.Query);
+            return GetAuthorization(GetToken(consumer, user), verb, uri.AbsolutePath, uri.Query, additionalParameters: additionalParameters);
         }
 
         public IToken GetToken(IConsumer consumer, IUser user)
@@ -77,7 +78,7 @@ namespace Xero.Api.Example.Applications
 
         protected abstract string AuthorizeUser(IToken oauthToken);
         protected abstract string CreateSignature(IToken token, string verb, Uri uri, string verifier,
-            bool renewToken = false, string callback = null);
+            bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null);
 
         protected abstract IToken RenewToken(IToken sessionToken, IConsumer consumer);
 
@@ -113,7 +114,7 @@ namespace Xero.Api.Example.Applications
         }
 
         protected string GetAuthorization(IToken token, string verb, string endpoint, string query = null,
-            string verifier = null, bool renewToken = false, string callback = null)
+            string verifier = null, bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
             var uri = new UriBuilder(BaseUri)
             {
@@ -125,7 +126,7 @@ namespace Xero.Api.Example.Applications
                 uri.Query = query.TrimStart('?');
             }
 
-            return CreateSignature(token, verb, uri.Uri, verifier, renewToken, callback);
+            return CreateSignature(token, verb, uri.Uri, verifier, renewToken, callback, additionalParameters);
         }
     }
 }

--- a/Xero.Api/Common/XeroApi.cs
+++ b/Xero.Api/Common/XeroApi.cs
@@ -16,10 +16,10 @@ namespace Xero.Api.Common
             BaseUri = baseUri;
         }
 
-        protected XeroApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
+        protected XeroApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter, bool useFormUrlEncodedPutsAndPosts = false)
             : this(baseUri)
         {
-            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter);
+            Client = new XeroHttpClient(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter, useFormUrlEncodedPutsAndPosts);
         }
 
         public string UserAgent

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -22,8 +22,8 @@ namespace Xero.Api.Core
         {
         }
 
-        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter)
-            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter)
+        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper readMapper, IXmlObjectMapper writeMapper, IRateLimiter rateLimiter, bool useFormUrlEncodedPutsAndPosts = false)
+            : base(baseUri, auth, consumer, user, readMapper, writeMapper, rateLimiter, useFormUrlEncodedPutsAndPosts)
         {
             Connect();
         }
@@ -33,8 +33,8 @@ namespace Xero.Api.Core
         {
         }
 
-        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IRateLimiter rateLimiter)
-            : this(baseUri, auth, consumer, user, new DefaultMapper(), new DefaultMapper(), rateLimiter)
+        public XeroCoreApi(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IRateLimiter rateLimiter, bool useFormUrlEncodedPutsAndPosts = false)
+            : this(baseUri, auth, consumer, user, new DefaultMapper(), new DefaultMapper(), rateLimiter, useFormUrlEncodedPutsAndPosts)
         {
         }
 

--- a/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/XeroHttpClient.cs
@@ -26,16 +26,15 @@ namespace Xero.Api.Infrastructure.Http
             XmlMapper = xmlMapper;
         }
 
-        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user,
-            IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
+        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper)
             : this(baseUri, auth, consumer, user, jsonMapper, xmlMapper, null)
         {
         }
 
-        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper, IRateLimiter rateLimiter)
+        public XeroHttpClient(string baseUri, IAuthenticator auth, IConsumer consumer, IUser user, IJsonObjectMapper jsonMapper, IXmlObjectMapper xmlMapper, IRateLimiter rateLimiter, bool useFormUrlEncodedPutsAndPosts = false)
             : this(jsonMapper, xmlMapper)
         {
-            Client = new HttpClient(baseUri, auth, consumer, user, rateLimiter);
+            Client = new HttpClient(baseUri, auth, consumer, user, rateLimiter, useFormUrlEncodedPutsAndPosts);
         }
 
         public DateTime? ModifiedSince { get; set; }

--- a/Xero.Api/Infrastructure/Interfaces/IAuthenticator.cs
+++ b/Xero.Api/Infrastructure/Interfaces/IAuthenticator.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Xero.Api.Infrastructure.Interfaces
 {
     public interface IAuthenticator
     {
-        string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1);
+        string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1, IEnumerable<KeyValuePair<string, string>> additionalParameters = null);
         IToken GetToken(IConsumer consumer, IUser user);
 
         IUser User { get; set; }

--- a/Xero.Api/Infrastructure/OAuth/Signing/HmacSha1Signer.cs
+++ b/Xero.Api/Infrastructure/OAuth/Signing/HmacSha1Signer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.ThirdParty.Dust;
 using Xero.Api.Infrastructure.ThirdParty.Dust.Core;
@@ -11,7 +12,7 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
 {
     public class HmacSha1Signer
     {
-        public string CreateSignature(IToken token, Uri uri, string verb, string verifier = null, string callback = null)
+        public string CreateSignature(IToken token, Uri uri, string verb, string verifier = null, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
             var oAuthParameters = new OAuthParameters(
                 new ConsumerKey(token.ConsumerKey),
@@ -22,7 +23,7 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
                 string.Empty,
                 "1.0",
                 verifier,
-                token.Session, false, callback);
+                token.Session, false, callback, additionalParameters);
 
             var signatureBaseString =
                 new SignatureBaseString(

--- a/Xero.Api/Infrastructure/OAuth/Signing/RsaSha1Signer.cs
+++ b/Xero.Api/Infrastructure/OAuth/Signing/RsaSha1Signer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Security.Cryptography.X509Certificates;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.ThirdParty.Dust;
@@ -13,7 +15,7 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
     public class RsaSha1Signer
     {
         public string CreateSignature(X509Certificate2 certificate, IToken token, Uri uri, string verb,
-            string verifier = null, bool renewToken = false, string callback = null)
+            string verifier = null, bool renewToken = false, string callback = null, IEnumerable<KeyValuePair<string, string>> additionalParameters = null)
         {
             var oAuthParameters = new OAuthParameters(
                 new ConsumerKey(token.ConsumerKey),
@@ -26,7 +28,8 @@ namespace Xero.Api.Infrastructure.OAuth.Signing
                 verifier,
                 token.Session,
                 renewToken,
-                callback);
+                callback,
+                additionalParameters);
 
             var signatureBaseString =
                 new SignatureBaseString(

--- a/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/OAuthParameters.cs
+++ b/Xero.Api/Infrastructure/ThirdParty/Dust/Core/SignatureBaseStringParts/Parameters/OAuthParameters.cs
@@ -1,4 +1,5 @@
-﻿using Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.Parameters.Nonce;
+﻿using System.Collections.Generic;
+using Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.Parameters.Nonce;
 using Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.Parameters.Timestamp;
 using Xero.Api.Infrastructure.ThirdParty.Dust.Lang;
 
@@ -14,8 +15,10 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
         private readonly string _nonce, _timestamp, _verifier, _session;
         private readonly bool _renewToken;
         private readonly string _callback;
+        private readonly IEnumerable<KeyValuePair<string, string>> _additionalParameters;
 
-	    public static OAuthParameters Empty = new OAuthParameters(
+
+        public static OAuthParameters Empty = new OAuthParameters(
 	        new ConsumerKey(string.Empty), 
 	        new TokenKey(string.Empty), 
 	        string.Empty, 
@@ -36,8 +39,9 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
             string verifier = null,
             string session = null,
             bool renewToken = false,
-            string callback = null
-		)
+            string callback = null,
+            IEnumerable<KeyValuePair<string, string>> additionalParameters = null
+        )
         {
     	    _key = key;
             _tokenKey = tokenKey;
@@ -51,6 +55,7 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
     	    _timestamp = timestamps.Next();
 	        _renewToken = renewToken;
 	        _callback = callback;
+            _additionalParameters = additionalParameters;
         }
 
 	    internal Parameters List() {
@@ -80,6 +85,12 @@ namespace Xero.Api.Infrastructure.ThirdParty.Dust.Core.SignatureBaseStringParts.
                     if (!string.IsNullOrWhiteSpace(_callback))
                     {
                         it.Add(Callback);
+                    }
+
+                    if (_additionalParameters != null) {
+                        foreach (var kvPair in _additionalParameters) {
+                            it.Add(new Parameter(kvPair.Key, kvPair.Value));
+                        }
                     }
                 });
     	}


### PR DESCRIPTION
This adds support to the wrapper to submit PUTs and POSTs as content-type `application/x-www-form-urlencoded` rather than `application/xml`. This is as mandated [by your API docs](https://developer.xero.com/documentation/api/requests-and-responses#postandput) as well as mandated by your support team as part of being added to the US Add-on Marketplace.

Although I'm personally very happy to use `application/xml`, our application submission was not accepted onto the Xero US Add-on Marketplace as we where not submitting our POSTs/PUTs as `application/x-www-form-urlencoded`.

I've made sure not to change the default behaviour of anything, the new functionality is opt-in.