### PR TITLE
Handle Australian Payroll Tracking Categories correctly

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/Settings.cs
+++ b/Xero.Api/Payroll/Australia/Model/Settings.cs
@@ -11,11 +11,24 @@ namespace Xero.Api.Payroll.Australia.Model
         public List<Account> Accounts { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public List<TrackingCategory> TrackingCategories { get; set; }
+        public TrackingCategories TrackingCategories { get; set; }
 
         [DataMember]
         public int DaysInPayrollYear { get; set; }
 
         public IList<Settings> Values { get; private set; }
     }
+
+    [DataContract(Namespace = "")]
+    public class TrackingCategories
+    {
+        [DataMember(EmitDefaultValue = false)]
+        public TrackingCategory EmployeeGroups { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public TrackingCategory TimesheetCategories { get; set; }
+
+    }
+
+
 }


### PR DESCRIPTION
HI, noticed a problem when selecting Timesheet Categories from the Settings API for Australian Payroll - the API actually uses not a list of Tracking Category, but an object containing two specifically named objects.
Would be great if this could come back into the master branch.