### PR TITLE
Added missing value None to the BankAccountType enum

### DIFF
--- a/Xero.Api/Core/Model/Types/BankAccountType.cs
+++ b/Xero.Api/Core/Model/Types/BankAccountType.cs
@@ -15,5 +15,7 @@ namespace Xero.Api.Core.Model.Types
         CreditCard,
         [EnumMember(Value = "PAYPAL")]
         Paypal,
+        [EnumMember(Value = "NONE")]
+        None,
     }
 }


### PR DESCRIPTION
Hi, it looks like there is a missing bank account type in the mapping. I get an exception very often when getting a bill from Xero. Despite of the fact this exception is being swallowed somewhere I think the enum should be mapped correctly.