### PR TITLE
Updated Nuget dependency on Newtonsoft.Json

### DIFF
--- a/nuget.nuspec
+++ b/nuget.nuspec
@@ -17,7 +17,7 @@
     <dependencies>
         <group>
             <dependency id="System.Data.SQLite" version="[1.0,)"/>
-            <dependency id="NewtonSoft.Json" version="[9.0.1,)"/>            
+            <dependency id="Newtonsoft.Json" version="[9.0.1,)"/>            
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Orginally NewtonSoft.Json (capital S).

This caused a duplicate key exception during startup of referencing application if another library was used with a dependency on Newtonsoft.Json.