### PR TITLE
Changed model types for AmericanPayroll

### DIFF
--- a/Xero.Api/Payroll/America/Endpoints/PayItemsEndpoint.cs
+++ b/Xero.Api/Payroll/America/Endpoints/PayItemsEndpoint.cs
@@ -1,0 +1,16 @@
+﻿using Xero.Api.Infrastructure.Http;
+using Xero.Api.Payroll.America.Model;
+using Xero.Api.Payroll.America.Request;
+using Xero.Api.Payroll.America.Response;
+using Xero.Api.Payroll.Common;
+
+namespace Xero.Api.Payroll.America.Endpoints
+{
+    public class PayItemsEndpoint : PayrollEndpoint<PayItemsEndpoint, PayItems, PayItemsRequest, PayItemsResponse>
+    {
+        public PayItemsEndpoint(XeroHttpClient client)
+            : base(client, "payroll.xro/1.0/PayItems")
+        {
+        }
+    }
+}

--- a/Xero.Api/Payroll/America/Model/BankAccount.cs
+++ b/Xero.Api/Payroll/America/Model/BankAccount.cs
@@ -16,10 +16,10 @@ namespace Xero.Api.Payroll.America.Model
         public AccountType AccountType { get; set; }
 
         [DataMember]
-        public int RoutingNumber { get; set; }
+        public string RoutingNumber { get; set; }
 
         [DataMember]
-        public int AccountNumber { get; set; }
+        public string AccountNumber { get; set; }
 
         [DataMember]
         public decimal? Amount { get; set; }

--- a/Xero.Api/Payroll/America/Model/SalaryAndWage.cs
+++ b/Xero.Api/Payroll/America/Model/SalaryAndWage.cs
@@ -7,7 +7,7 @@ namespace Xero.Api.Payroll.America.Model
     [DataContract(Namespace = "")]
     public class SalaryAndWage
     {
-        [DataMember(Name = "SalaryAndWagesID")]
+        [DataMember(Name = "SalaryAndWagesID", EmitDefaultValue = false)]
         public Guid Id { get; set; }
 
         [DataMember(Name = "EarningsTypeID")]

--- a/Xero.Api/Payroll/America/Request/PayItemsRequest.cs
+++ b/Xero.Api/Payroll/America/Request/PayItemsRequest.cs
@@ -9,7 +9,7 @@ namespace Xero.Api.Payroll.America.Request
 {
     [DataContract(Namespace = "", Name = "PayItems")]
     public class PayItemsRequest : XeroRequest<PayItems>
-    {/*
+    {
         [DataMember(EmitDefaultValue = false)]
         public List<EarningsType> EarningsTypes { get { return PayItems.EarningsTypes; } }
 
@@ -34,6 +34,6 @@ namespace Xero.Api.Payroll.America.Request
         public void AddRange(IEnumerable<PayItems> value)
         {
             PayItems = value.FirstOrDefault();
-        }*/
+        }
     }
 }

--- a/Xero.Api/Payroll/America/Request/PayItemsRequest.cs
+++ b/Xero.Api/Payroll/America/Request/PayItemsRequest.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Xero.Api.Common;
+using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Payroll.America.Model;
+
+namespace Xero.Api.Payroll.America.Request
+{
+    [DataContract(Namespace = "", Name = "PayItems")]
+    public class PayItemsRequest : XeroRequest<PayItems>
+    {/*
+        [DataMember(EmitDefaultValue = false)]
+        public List<EarningsType> EarningsTypes { get { return PayItems.EarningsTypes; } }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<DeductionType> DeductionTypes { get { return PayItems.DeductionTypes; } }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<TimeOffType> TimeOffTypes { get { return PayItems.TimeOffTypes; } }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<ReimbursementType> ReimbursementTypes { get { return PayItems.ReimbursementTypes; } }
+
+        private PayItems PayItems { get; set; }
+        
+        public IList<PayItems> Items { get { return new[] { PayItems }; } }
+
+        public void Add(PayItems value)
+        {
+            PayItems = value;
+        }
+
+        public void AddRange(IEnumerable<PayItems> value)
+        {
+            PayItems = value.FirstOrDefault();
+        }*/
+    }
+}

--- a/Xero.Api/Payroll/America/Response/PayItemsResponse.cs
+++ b/Xero.Api/Payroll/America/Response/PayItemsResponse.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Xero.Api.Common;
+using Xero.Api.Infrastructure.Interfaces;
+using Xero.Api.Payroll.America.Model;
+
+namespace Xero.Api.Payroll.America.Response
+{
+    public class PayItemsResponse : XeroResponse<PayItems>
+    {
+        public IList<PayItems> PayItems { get; set; }
+
+        public override IList<PayItems> Values
+        {
+            get { return PayItems; }
+        }
+    }
+}

--- a/Xero.Api/Payroll/AmericanPayroll.cs
+++ b/Xero.Api/Payroll/AmericanPayroll.cs
@@ -24,6 +24,7 @@ namespace Xero.Api.Payroll
 
         public WorkLocationsEndpoint WorkLocations { get; private set; }
         public PayStubsEndpoint PayStubs { get; private set; }
+        public PayItemsEndpoint PayItems { get; private set; }
         public PaySchedulesEndpoint PaySchedules { get; private set; }
         public EmployeesEndpoint Employees { get; private set; }
         public PayRunsEndpoint PayRuns { get; private set; }
@@ -34,6 +35,7 @@ namespace Xero.Api.Payroll
         {
             WorkLocations = new WorkLocationsEndpoint(Client);
             PayStubs = new PayStubsEndpoint(Client);
+            PayItems = new PayItemsEndpoint(Client);
             PaySchedules = new PaySchedulesEndpoint(Client);
             Employees = new EmployeesEndpoint(Client);
             PayRuns = new PayRunsEndpoint(Client);

--- a/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
+++ b/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(Name = "EarningsRateID", EmitDefaultValue = false)]
         public Guid Id { get; set; }
 
-        [DataMember]
+        [DataMember(Name = "EarningsType")]
         public string Name { get; set; }
 
         [DataMember]

--- a/Xero.Api/Payroll/Australia/Model/PayItems.cs
+++ b/Xero.Api/Payroll/Australia/Model/PayItems.cs
@@ -6,7 +6,7 @@ namespace Xero.Api.Payroll.Australia.Model
     [DataContract(Namespace = "")]
     public class PayItems
     {
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember(Name="EarningsTypes")]
         public List<EarningsRate> EarningsRates { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -256,11 +256,14 @@
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\UrlEncoder.cs" />
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\HttpEncoder.cs" />
     <Compile Include="Infrastructure\ThirdParty\HttpUtility\HttpUtility.cs" />
+    <Compile Include="Payroll\America\Endpoints\PayItemsEndpoint.cs" />
     <Compile Include="Payroll\America\Endpoints\TimesheetsEndpoint.cs" />
     <Compile Include="Payroll\America\Model\Timesheet.cs" />
     <Compile Include="Payroll\America\Model\TimesheetLine.cs" />
     <Compile Include="Payroll\America\Model\Types\State.cs" />
+    <Compile Include="Payroll\America\Request\PayItemsRequest.cs" />
     <Compile Include="Payroll\America\Request\TimesheetsRequest.cs" />
+    <Compile Include="Payroll\America\Response\PayItemsResponse.cs" />
     <Compile Include="Payroll\America\Response\SettingsResponse.cs" />
     <Compile Include="Payroll\America\Response\TimesheetsResponse.cs" />
     <Compile Include="Payroll\Australia\Endpoints\TimesheetsEndpoint.cs" />


### PR DESCRIPTION
Changed from Int32 to String for both AccountNumber and RoutingNumber.  And Int32 is not large enough to hold most American bank account numbers and the XERO API is expecting a string.