### PR TITLE
Payslips api not reading ContributionType If ContributionType =SuperannuationGuaranteeCharge

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperannuationLine.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Payroll.Australia.Model
         public Guid SuperMembershipId { get; set; }
 
         [DataMember]
-        public SuperannuationContributionType? ContributionType { get; set; }
+        public SuperannuationContributionType ContributionType { get; set; }
 
         [DataMember]
         public SuperannuationCalculationType? CalculationType { get; set; }


### PR DESCRIPTION
It retrieves ContributionType=null, works fine for other types. making it non nullable fixes it.
used
api.Payslips.Find(payslipId);