### PR TITLE
* PayItems.EarningRates working again and added EarningRates.IsReportableAsW1

### DIFF
--- a/PayrollTests.AU/Integration/PayItems/Find.cs
+++ b/PayrollTests.AU/Integration/PayItems/Find.cs
@@ -18,5 +18,16 @@ namespace PayrollTests.AU.Integration.PayItems
             var items = Api.PayItems.Page(1).Find();
             Assert.IsNotNull(items);
         }
+
+        [Test]
+        public void Find_EarningRates()
+        {
+            var items = Api.PayItems.Find();
+
+            foreach(var payItem in items)
+            {
+                Assert.IsNotNull(payItem.EarningsRates);
+            }
+        }
     }
 }

--- a/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
+++ b/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
@@ -32,6 +32,9 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember]
         public bool IsExemptFromSuper { get; set; }
 
+        [DataMember]
+        public bool IsReportableAsW1 { get; set; }
+
         [DataMember(EmitDefaultValue = false)]
         public decimal? RatePerUnit { get; set; }
 

--- a/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
+++ b/Xero.Api/Payroll/Australia/Model/EarningsRate.cs
@@ -11,7 +11,7 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(Name = "EarningsRateID", EmitDefaultValue = false)]
         public Guid Id { get; set; }
 
-        [DataMember(Name = "EarningsType")]
+        [DataMember]
         public string Name { get; set; }
 
         [DataMember]

--- a/Xero.Api/Payroll/Australia/Model/PayItems.cs
+++ b/Xero.Api/Payroll/Australia/Model/PayItems.cs
@@ -6,7 +6,7 @@ namespace Xero.Api.Payroll.Australia.Model
     [DataContract(Namespace = "")]
     public class PayItems
     {
-        [DataMember(Name="EarningsTypes")]
+        [DataMember(EmitDefaultValue = false)]
         public List<EarningsRate> EarningsRates { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
*reverted changes from f7213975980561ad2032b6ea24c0ce0b1bdf01f to get PayItems.EarningRates working again
* added EarningRates.IsReportableAsW1 as it was missing from the SDK
