### PR TITLE
Add overloads to Find to stop resetting the query parameters

### DIFF
--- a/CoreTests/Integration/Contacts/Find.cs
+++ b/CoreTests/Integration/Contacts/Find.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using Xero.Api.Core.Model.Status;
 
@@ -15,6 +16,19 @@ namespace CoreTests.Integration.Contacts
 
             Assert.True(Api.Contacts.Page(1).Find().Any());
         }
+        
+        [Test]
+        [TestCase(true, "page=1")]
+        [TestCase(false, "page=1&includeArchived=true")]
+        public void find_by_page_reset_query(bool resetQuery, string expectedQuery)
+        {
+            Given_a_contact();
+
+            var api = Api.Contacts.IncludeArchived(true).Page(1);
+            
+            Assert.True(api.Find(resetQuery: resetQuery).Any());
+            Assert.That(api.QueryString, Is.EqualTo(expectedQuery));
+        }
 
         [Test]
         public void find_by_id()
@@ -26,6 +40,20 @@ namespace CoreTests.Integration.Contacts
                 .Id;
 
             Assert.AreEqual(expected, id);
+        }
+
+        [Test]
+        [TestCase(true, "page=1")]
+        [TestCase(false, "page=1&includeArchived=true")]
+        public void find_by_id_reset_query(bool resetQuery, string expectedQuery)
+        {
+            var expected = Given_a_contact().Id;
+            
+            var api = Api.Contacts.IncludeArchived(true);
+            
+            api.Find(expected, resetQuery: resetQuery);
+
+            Assert.That(api.QueryString, Is.EqualTo(expectedQuery));
         }
 
         [Test]

--- a/CoreTests/Integration/Invoices/Find.cs
+++ b/CoreTests/Integration/Invoices/Find.cs
@@ -17,6 +17,19 @@ namespace CoreTests.Integration.Invoices
             
             Assert.Greater(invoices.Count(), 0);
         }
+        
+        [Test]
+        [TestCase(true, "unitdp=4&page=1")]
+        [TestCase(false, "page=1")]
+        public void find_by_page_reset_query(bool resetQuery, string expectedQuery)
+        {
+            Given_an_invoice();
+
+            var api = Api.Invoices.UseFourDecimalPlaces(false).Page(1);
+            
+            Assert.True(api.Find(resetQuery: resetQuery).Any());
+            Assert.That(api.QueryString, Is.EqualTo(expectedQuery));
+        }
 
         [Test]
         public void find_by_id()
@@ -25,6 +38,20 @@ namespace CoreTests.Integration.Invoices
             var id = Api.Invoices.Find(expected).Id;
 
             Assert.AreEqual(expected, id);
+        }
+
+        [Test]
+        [TestCase(true, "unitdp=4&page=1")]
+        [TestCase(false, "page=1")]
+        public void find_by_id_reset_query(bool resetQuery, string expectedQuery)
+        {
+            var expected  = Given_an_invoice().Id;
+            
+            var api = Api.Invoices.UseFourDecimalPlaces(false);
+                
+            api.Find(expected, resetQuery: resetQuery);
+
+            Assert.That(api.QueryString, Is.EqualTo(expectedQuery));
         }
 
         [Test]

--- a/Xero.Api/Common/IXeroReadEndpoint.cs
+++ b/Xero.Api/Common/IXeroReadEndpoint.cs
@@ -17,8 +17,11 @@ namespace Xero.Api.Common
         T OrderByDescending(string query);
         T UseFourDecimalPlaces(bool use4Dp);
         IEnumerable<TResult> Find();
+        IEnumerable<TResult> Find(bool resetQuery);
         TResult Find(Guid child);
+        TResult Find(Guid child, bool resetQuery);
         TResult Find(string child);
+        TResult Find(string child, bool resetQuery);
         void ClearQueryString();
     }
 }

--- a/Xero.Api/Common/XeroReadEndpoint.cs
+++ b/Xero.Api/Common/XeroReadEndpoint.cs
@@ -71,17 +71,32 @@ namespace Xero.Api.Common
 
         public virtual IEnumerable<TResult> Find()
         {
-            return Get(ApiEndpointUrl, null);
+            return Find(true);
+        }
+
+        public virtual IEnumerable<TResult> Find(bool resetQuery)
+        {
+            return Get(ApiEndpointUrl, null, resetQuery);
         }
 
         public virtual TResult Find(Guid child)
         {
-            return Find(child.ToString("D"));
+            return Find(child, true);
+        }
+
+        public virtual TResult Find(Guid child, bool resetQuery)
+        {
+            return Find(child.ToString("D"), resetQuery);
         }
 
         public TResult Find(string child)
         {
-            return Get(ApiEndpointUrl, "/" + child).FirstOrDefault();
+            return Find(child, true);
+        }
+
+        public TResult Find(string child, bool resetQuery)
+        {
+            return Get(ApiEndpointUrl, "/" + child, resetQuery).FirstOrDefault();
         }
 
         public virtual void ClearQueryString()
@@ -158,7 +173,7 @@ namespace Xero.Api.Common
             return (T)this;
         }
 
-        private IEnumerable<TResult> Get(string endpoint, string child)
+        private IEnumerable<TResult> Get(string endpoint, string child, bool resetQuery)
         {
             try
             {
@@ -176,7 +191,10 @@ namespace Xero.Api.Common
             }
             finally
             {
-                ClearQueryString();
+                if (resetQuery)
+                {
+                    ClearQueryString();
+                }
             }
         }
     }


### PR DESCRIPTION
Use case: A single method that can provide ALL items across multiple pages
Change: Add an overload of `Find` that *does not* reset the query

I wanted a single method that I could use instead of `Find` to iterate over all pages given a defined query. Instead of provide that functionality (not sure if it's appropriate in this SDK?) I made a change to the lower-level `Find` method to specify the query should not be reset, enabling the following code (where `endpoint` is a pageable endpoint that may already have configured parameters like 'IncludeArchived' for contacts) :

````c#
            const int pageSize = 100;
            var all = new List<TResult>();

            var currentPage = 1;

            while (true)
            {
                var pageOfItems = endpoint.Page(currentPage).Find(resetQuery: false);

                all.AddRange(pageOfItems);

                // We have got fewer than the page size of items,
                // we must therefore be at the end
                if (pageOfItems.Count() < pageSize)
                {
                    break;
                }

                currentPage++;
            }
````

I chose to introduce a new set of methods that have the extra parameter instead of an optional parameter, although not sure if that is the best fit.

Would also be happy to instead have a method for loading ALL items in a set across multiple pages in the SDK