### PR TITLE
SuperLine requires CalculationType and ContributionType

### DIFF
--- a/Xero.Api/Payroll/Australia/Model/SuperLine.cs
+++ b/Xero.Api/Payroll/Australia/Model/SuperLine.cs
@@ -10,10 +10,10 @@ namespace Xero.Api.Payroll.Australia.Model
         [DataMember(Name = "SuperMembershipID")]
         public Guid SuperMembershipId { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember]
         public SuperannuationCalculationType CalculationType { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
+        [DataMember]
         public SuperannuationContributionType ContributionType { get; set; }
 
         [DataMember(EmitDefaultValue = false)]


### PR DESCRIPTION
It seems that SuperLine (in PayTemplate) now requires CalculationType and ContributionType similar to SuperannuationLine in a Payslip. CalculationType and ContributionType properties no longer emit default values