### PR TITLE
changed NotAvailableException to a public class

### DIFF
--- a/Xero.Api/Infrastructure/Exceptions/NotAvailableException.cs
+++ b/Xero.Api/Infrastructure/Exceptions/NotAvailableException.cs
@@ -4,7 +4,7 @@ using System.Net;
 namespace Xero.Api.Infrastructure.Exceptions
 {
     [Serializable]
-    internal class NotAvailableException
+    public class NotAvailableException
         : XeroApiException
     {
         public NotAvailableException() { }


### PR DESCRIPTION
Seems that NotAvailableException is internal, and not publicly available out side the wrapper.
Not sure if this is by design? but would help others using the wrapper.