### PR TITLE
Contacts Endpoint - Method to fetch multiple contacts at the same time.

### DIFF
--- a/CoreTests/Integration/Contacts/Find.cs
+++ b/CoreTests/Integration/Contacts/Find.cs
@@ -29,6 +29,16 @@ namespace CoreTests.Integration.Contacts
         }
 
         [Test]
+        public void find_by_id_list()
+        {
+            var created = Given_a_contact();
+            var contacts = Api.Contacts.Ids(new[] { created.Id }).Find().ToList();
+
+            Assert.AreEqual(1, contacts.Count());
+            Assert.AreEqual(created.Id, contacts.First().Id);
+        }
+
+        [Test]
         public void find_by_value()
         {
             var expected = Given_a_contact().Name;

--- a/Xero.Api/Core/Endpoints/ContactsEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/ContactsEndpoint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xero.Api.Common;
 using Xero.Api.Core.Endpoints.Base;
@@ -15,6 +16,7 @@ namespace Xero.Api.Core.Endpoints
     {
         IContactsEndpoint IncludeArchived(bool include);
         ContactCisSetting GetCisSettings(Guid id);
+        IContactsEndpoint Ids(IEnumerable<Guid> ids);
     }
 
     public class ContactsEndpoint
@@ -52,6 +54,13 @@ namespace Xero.Api.Core.Endpoints
         {
             base.ClearQueryString();
             Page(1);
+        }
+
+		public IContactsEndpoint Ids(IEnumerable<Guid> ids)
+        {
+            AddParameter("ids", string.Join(",", ids));
+
+            return this;
         }
     }
 }


### PR DESCRIPTION
Similar to how InvoicesEndpoint has an Ids method to find multiple
Invoices at the same time, this method is for retrieving multiple
contacts at the same time which helps with batching requests and not
hitting the API request limit as quickly when fetching a lot of data, and I've added a unit test for completeness.