### PR TITLE
While condition is always true the second time

### DIFF
--- a/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
+++ b/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
@@ -31,7 +31,7 @@ namespace Xero.Api.Infrastructure.RateLimiter
         /// </summary>
         public void WaitUntilLimit()
         {
-            if (rateLimiter.Count >= _qty)
+            if (rateLimiter.Count == _qty)
             {
                 var diff = rateLimiter.Peek().Add(_duration) - DateTime.UtcNow;
                 if (diff.TotalMilliseconds > 0)
@@ -47,7 +47,7 @@ namespace Xero.Api.Infrastructure.RateLimiter
         /// <returns>True if we're over the limit, false if we've got some allocation left</returns>
         public bool CheckLimit()
         {
-            return (rateLimiter.Count >= _qty && rateLimiter.Peek().Add(_duration) > DateTime.UtcNow);
+            return (rateLimiter.Count == _qty && rateLimiter.Peek().Add(_duration) > DateTime.UtcNow);
         }
     }
 }

--- a/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
+++ b/Xero.Api/Infrastructure/RateLimiter/RateLimiter.cs
@@ -31,7 +31,7 @@ namespace Xero.Api.Infrastructure.RateLimiter
         /// </summary>
         public void WaitUntilLimit()
         {
-            while (rateLimiter.Count >= _qty)
+            if (rateLimiter.Count >= _qty)
             {
                 var diff = rateLimiter.Peek().Add(_duration) - DateTime.UtcNow;
                 if (diff.TotalMilliseconds > 0)


### PR DESCRIPTION
I changed the `while` to an `if` because the previous implementation would always return `false` the second time that condition was checked. The queue is dequeued with each enqueue and all the properties involved are private, so it's safe to assume the condition only needs to be checked once. Note, this is not thread safe, but RateLimiter already is not thread safe (https://github.com/XeroAPI/Xero-Net/issues/248).