### PR TITLE
Change Organisation map SalesTaxBasis to SalesTaxBasisType

### DIFF
--- a/CoreTests/Integration/Organisation/Find.cs
+++ b/CoreTests/Integration/Organisation/Find.cs
@@ -10,7 +10,7 @@ namespace CoreTests.Integration.Organisation
         [Test]
         public void can_get_the_organisation_sales_tax_basis()
         {
-            var test = Api.Organisation.SalesTaxBasis;
+            var test = Api.Organisation.SalesTaxBasisType;
 
             Assert.True(Enum.IsDefined(typeof(SalesTaxBasisType), test));
         }

--- a/CoreTests/Integration/Organisation/Find.cs
+++ b/CoreTests/Integration/Organisation/Find.cs
@@ -10,7 +10,7 @@ namespace CoreTests.Integration.Organisation
         [Test]
         public void can_get_the_organisation_sales_tax_basis()
         {
-            var test = Api.Organisation.SalesTaxBasisType;
+            var test = Api.Organisation.SalesTaxBasis;
 
             Assert.True(Enum.IsDefined(typeof(SalesTaxBasisType), test));
         }

--- a/Xero.Api/Common/XeroReadEndpoint.cs
+++ b/Xero.Api/Common/XeroReadEndpoint.cs
@@ -172,7 +172,8 @@ namespace Xero.Api.Common
                 Client.ModifiedSince = _modifiedSince;
                 Client.Parameters = Parameters;
 
-                return Client.Get<TResult, TResponse>(endpoint + (child ?? string.Empty));
+                var result = Client.Get<TResult, TResponse>(endpoint + (child ?? string.Empty));
+                return result;
             }
             finally
             {

--- a/Xero.Api/Core/Model/Organisation.cs
+++ b/Xero.Api/Core/Model/Organisation.cs
@@ -76,7 +76,7 @@ namespace Xero.Api.Core.Model
         public PaymentTerms PaymentTerms { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public SalesTaxBasisType SalesTaxBasisType { get; set; }
+        public SalesTaxBasisType SalesTaxBasis { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public SalesTaxPeriodType SalesTaxPeriod { get; set; }

--- a/Xero.Api/Core/Model/Organisation.cs
+++ b/Xero.Api/Core/Model/Organisation.cs
@@ -75,8 +75,8 @@ namespace Xero.Api.Core.Model
         [DataMember(EmitDefaultValue = false)]
         public PaymentTerms PaymentTerms { get; set; }
 
-        [DataMember(EmitDefaultValue = false)]
-        public SalesTaxBasisType SalesTaxBasis { get; set; }
+        [DataMember(Name = "SalesTaxBasis", EmitDefaultValue = false)]
+        public SalesTaxBasisType SalesTaxBasisType { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public SalesTaxPeriodType SalesTaxPeriod { get; set; }

--- a/Xero.Api/Core/Model/Types/SalesTaxBasisType.cs
+++ b/Xero.Api/Core/Model/Types/SalesTaxBasisType.cs
@@ -7,8 +7,10 @@ namespace Xero.Api.Core.Model.Types
     {
         [EnumMember(Value = "NONE")]
         None,
+        [EnumMember(Value = "ACCRUALS")]
+        Accurals=1,
         [EnumMember(Value = "ACCRUAL")]
-        Accural,
+        Accural = 1,
         [EnumMember(Value = "CASH")]
         Cash,
         [EnumMember(Value = "INVOICE")]


### PR DESCRIPTION
To fix issue 
https://github.com/XeroAPI/Xero-Net/issues/377

SalesTaxBasis wasn't populated because of the class member name is "SalesTaxBasisType", by mapping it to SalesTaxBasis will fix the problem.

Also, for US org, it seems "ACCRUAL" is showing as "ACCRUALS", so I've added that to enum SalesTaxBasisType.. 😭 

ping @MJMortimer