### PR TITLE
383 email invoice timeout

### DIFF
--- a/Xero.Api/Infrastructure/Http/Response.cs
+++ b/Xero.Api/Infrastructure/Http/Response.cs
@@ -31,8 +31,6 @@ namespace Xero.Api.Infrastructure.Http
             {
                 Headers[item] = inner.Headers[item];
             }
-
-            inner.Close();
         }
 
         public string Body

--- a/Xero.Api/Infrastructure/Http/Response.cs
+++ b/Xero.Api/Infrastructure/Http/Response.cs
@@ -31,6 +31,8 @@ namespace Xero.Api.Infrastructure.Http
             {
                 Headers[item] = inner.Headers[item];
             }
+
+            inner.Close();
         }
 
         public string Body


### PR DESCRIPTION
Attempt to resolve #383 .

Added inner.close to Xero.Api.Infrastructure.Http: internal Response(HttpWebResponse inner)

Closing the HttpWebResponse seems to resolve the issue that after sending ~2 emails, the ServicePointManager uses up its two connections (default limit) and any further connections time out. 