### PR TITLE
Added PaymentServices Endpoints

### DIFF
--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -140,6 +140,9 @@
     <Compile Include="Integration\ManualJournals\ManualJournalsTest.cs" />
     <Compile Include="Integration\ManualJournals\Update.cs" />
     <Compile Include="Integration\Organisation\Find.cs" />
+    <Compile Include="Integration\PaymentServices\Create.cs" />
+    <Compile Include="Integration\PaymentServices\Find.cs" />
+    <Compile Include="Integration\PaymentServices\PaymentServicesTest.cs" />
     <Compile Include="Integration\Payments\Create.cs" />
     <Compile Include="Integration\Payments\CreateForeignCurrency.cs" />
     <Compile Include="Integration\Payments\Delete.cs" />

--- a/CoreTests/Integration/PaymentServices/Create.cs
+++ b/CoreTests/Integration/PaymentServices/Create.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Xero.Api.Core.Model;
+
+namespace CoreTests.Integration.PaymentServices
+{
+	[TestFixture]
+	public class Create : PaymentServicesTest
+	{
+		[TestFixtureSetUp]
+		public void CreatePaymentServicesSetUp()
+		{
+			SetUp();
+		}
+
+		[Test]
+		public void create_payment_service()
+		{
+
+			const string url = "http://127.0.01/Xero/PayNow";
+			string paymentServiceName = "Unit Test PaymentService " + Random.GetRandomString(10);
+
+			var paymentService = Given_a_payment_service(paymentServiceName, url);
+
+			Assert.AreEqual(paymentServiceName, paymentService.PaymentServiceName);
+			Assert.AreEqual(url, paymentService.PaymentServiceUrl);
+
+		}
+
+	}
+}

--- a/CoreTests/Integration/PaymentServices/Find.cs
+++ b/CoreTests/Integration/PaymentServices/Find.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace CoreTests.Integration.PaymentServices
+{
+    public class Find : PaymentServicesTest
+    {
+        [TestFixtureSetUp]
+        public void PaymentServicesSetUp()
+        {
+            SetUp();
+        }
+
+        [Test]
+        public void find_single_payment_service()
+        {
+			string name = RandomPaymentServiceName();
+
+			var created = Given_a_payment_service(name, "http://127.0.0.1/PayNow");
+
+			var found = ListPaymentServices().FirstOrDefault();
+
+			Assert.IsNotNull(found);
+
+			Assert.IsNotNull(found.Id);
+
+			Assert.AreEqual(name, found.PaymentServiceName);
+			Assert.AreEqual("CUSTOM", found.PaymentServiceType);
+			Assert.AreEqual(created.PaymentServiceUrl, found.PaymentServiceUrl);
+		}
+
+        [Test]
+        public void find_payment_services()
+        {
+			Given_a_payment_service("Unit Test Payment Service 1", "http://127.0.0.1/PayNow");
+			Given_a_payment_service("Unit Test Payment Service 2", "http://127.0.0.1/PayNow");
+
+            var found = Api.PaymentServices.Find().ToList();
+
+            Assert.IsTrue(found.Where(ps => ps.PaymentServiceName.StartsWith("Unit Test Payment Service")).Count() == 2);
+        }
+    }
+}

--- a/CoreTests/Integration/PaymentServices/PaymentServicesTest.cs
+++ b/CoreTests/Integration/PaymentServices/PaymentServicesTest.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Xero.Api.Core;
+using Xero.Api.Core.Model;
+using Xero.Api.Core.Model.Status;
+using Xero.Api.Core.Model.Types;
+
+namespace CoreTests.Integration.PaymentServices
+{
+    public abstract class PaymentServicesTest : ApiWrapperTest
+    {
+		private IList<PaymentService> _paymentServices;
+
+		protected PaymentService Given_a_payment_service(string name, string url, string payNowText = "Tests Payment Service")
+		{
+			var fakePaymentService = CreatePaymentService(name, url, payNowText);
+
+			fakePaymentService.Id = Guid.NewGuid();
+			fakePaymentService.PaymentServiceType = "CUSTOM";
+
+			_paymentServices.Add(fakePaymentService);
+			return fakePaymentService;
+        }
+
+		protected string RandomPaymentServiceName()
+		{
+			return "Unit Test Payment Service " + Random.GetRandomString(10);
+		}
+
+		protected IList<PaymentService> ListPaymentServices()
+		{
+			return _paymentServices;
+		}
+
+		protected PaymentService CreatePaymentService(string name, string url, string payNowText = "Tests Payment Service")
+		{
+			var paymentService = new PaymentService
+			{
+				PaymentServiceName = name,
+				PaymentServiceUrl = url,
+				PayNowText = payNowText
+			};
+
+			return paymentService;
+		}
+
+    }
+}

--- a/Xero.Api/Core/Endpoints/PaymentServicesEndpoint.cs
+++ b/Xero.Api/Core/Endpoints/PaymentServicesEndpoint.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using Xero.Api.Core.Endpoints.Base;
+using Xero.Api.Core.Model;
+using Xero.Api.Core.Request;
+using Xero.Api.Core.Response;
+using Xero.Api.Infrastructure.Http;
+
+namespace Xero.Api.Core.Endpoints
+{
+    public interface IPaymentServicesEndpoint
+        : IXeroUpdateEndpoint<PaymentServicesEndpoint, PaymentService, PaymentServicesRequest, PaymentServicesResponse>
+    {
+
+		/// <summary>
+		/// Add a Custom Payment Service
+		/// </summary>
+		IEnumerable<PaymentService> Get(Guid brandingThemeId);
+
+		/// <summary>
+		/// Add a Payment Service to a Branding Theme
+		/// </summary>
+		void AddPaymentServiceToBrandingTheme(Guid brandingThemeId, Guid paymentServiceId);
+
+	}
+
+    public class PaymentServicesEndpoint
+		: XeroUpdateEndpoint<PaymentServicesEndpoint, PaymentService, PaymentServicesRequest, PaymentServicesResponse>, IPaymentServicesEndpoint
+	{
+        public PaymentServicesEndpoint(XeroHttpClient client) :
+            base(client, "/api.xro/2.0/PaymentServices")
+        {
+        }
+
+		/// <summary>
+		/// List payment services for a given Branding Theme
+		/// </summary>
+		///
+		/// <param name="brandingThemeId">Id of the Branding Theme</param>
+		///
+		/// <returns>List of PaymentServices enabled for this Branding Theme</returns>
+		public IEnumerable<PaymentService> Get(Guid brandingThemeId)
+		{
+			var found = Client.Get<PaymentService, PaymentServicesResponse>(string.Format("api.xro/2.0/BrandingThemes/{0:D}/PaymentServices", brandingThemeId));
+			return found;
+		}
+
+		/// <summary>
+		/// Add a Payment Service to a given Branding Theme
+		/// </summary>
+		///
+		/// <param name="brandingThemeId">Id of the Branding theme to enable the payment service for</param>
+		/// <param name="paymentServiceId">Id of the payment service</param>
+		public void AddPaymentServiceToBrandingTheme(Guid brandingThemeId, Guid paymentServiceId)
+		{
+			var item = new PaymentService { Id = paymentServiceId };
+			var request = new PaymentServicesRequest { item };
+
+			Client.Post<PaymentService, PaymentServicesResponse>(string.Format("api.xro/2.0/BrandingThemes/{0:D}/PaymentServices", brandingThemeId), request);
+		}
+
+	}
+
+}

--- a/Xero.Api/Core/IXeroCoreApi.cs
+++ b/Xero.Api/Core/IXeroCoreApi.cs
@@ -14,6 +14,7 @@ namespace Xero.Api.Core
         IBankTransactionsEndpoint BankTransactions { get; }
         IBankTransfersEndpoint BankTransfers { get; }
         IBatchPaymentsEndpoint BatchPayments { get; }
+        IPaymentServicesEndpoint PaymentServices { get; }
         IBrandingThemesEndpoint BrandingThemes { get; }
         IContactsEndpoint Contacts { get; }
         IContactGroupsEndpoint ContactGroups { get; }
@@ -126,6 +127,9 @@ namespace Xero.Api.Core
         Payment Create(Payment item);
         Payment Update(Payment item);
         
+        //Payment Services
+        PaymentService Create(PaymentService item);
+
         //PurchaseOrders
         IEnumerable<PurchaseOrder> Create(IEnumerable<PurchaseOrder> items);
         IEnumerable<PurchaseOrder> Update(IEnumerable<PurchaseOrder> items);

--- a/Xero.Api/Core/Model/PaymentService.cs
+++ b/Xero.Api/Core/Model/PaymentService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Xero.Api.Common;
+
+namespace Xero.Api.Core.Model
+{
+	/// <summary>
+	/// See Xero developer site for more info https://developer.xero.com/documentation/api/payment-services
+	/// </summary>
+	[DataContract(Namespace = "")]
+    public class PaymentService : CoreData, IHasId
+    {
+        [DataMember(Name = "PaymentServiceID")]
+        public Guid Id { get; set; }
+
+		[DataMember]
+		public string PaymentServiceName { get; set; }
+
+		[DataMember]
+		public string PaymentServiceUrl { get; set; }
+
+		[DataMember]
+		public string PayNowText { get; set; }
+
+		/// <summary>
+		/// This will always be CUSTOM for payment services created via the API.
+		/// </summary>
+		[DataMember]
+		public string PaymentServiceType { get; set; }
+    }
+}

--- a/Xero.Api/Core/Request/PaymentServicesRequest.cs
+++ b/Xero.Api/Core/Request/PaymentServicesRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.Serialization;
+using Xero.Api.Common;
+using Xero.Api.Core.Model;
+
+namespace Xero.Api.Core.Request
+{
+    [CollectionDataContract(Namespace = "", Name = "PaymentServices")]
+    public class PaymentServicesRequest : XeroRequest<PaymentService>
+    {
+    }
+}

--- a/Xero.Api/Core/Response/PaymentServicesResponse.cs
+++ b/Xero.Api/Core/Response/PaymentServicesResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Xero.Api.Common;
+using Xero.Api.Core.Model;
+
+namespace Xero.Api.Core.Response
+{
+    public class PaymentServicesResponse : XeroResponse<PaymentService>
+    {
+        public List<PaymentService> PaymentServices { get; set; }
+
+        public override IList<PaymentService> Values
+        {
+            get { return PaymentServices; }
+        }
+    }
+}

--- a/Xero.Api/Core/XeroCoreApi.cs
+++ b/Xero.Api/Core/XeroCoreApi.cs
@@ -61,6 +61,7 @@ namespace Xero.Api.Core
         public IOrganisationEndpoint Organisations { get; private set; }
         public IOverpaymentsEndpoint Overpayments { get; private set; }
         public IPaymentsEndpoint Payments { get; private set; }
+        public IPaymentServicesEndpoint PaymentServices { get; private set; }
         public PdfEndpoint PdfFiles { get; private set; }
         public IPrepaymentsEndpoint Prepayments { get; private set; }
         public IPurchaseOrdersEndpoint PurchaseOrders { get; private set; }
@@ -102,6 +103,7 @@ namespace Xero.Api.Core
             ManualJournals = new ManualJournalsEndpoint(Client);
             Overpayments = new OverpaymentsEndpoint(Client);
             Payments = new PaymentsEndpoint(Client);
+            PaymentServices = new PaymentServicesEndpoint(Client);
             PdfFiles = new PdfEndpoint(Client);
             Prepayments = new PrepaymentsEndpoint(Client);
             PurchaseOrders = new PurchaseOrdersEndpoint(Client);
@@ -208,6 +210,7 @@ namespace Xero.Api.Core
 
         #endregion
         
+
         #region ContactGroups
 
         public IEnumerable<ContactGroup> Create(IEnumerable<ContactGroup> items)
@@ -422,9 +425,30 @@ namespace Xero.Api.Core
             return Payments.Update(item);
         }
 
-        #endregion
+		#endregion
 
-        #region PurchaseOrders
+		#region PaymentServices
+
+		/// <summary>
+		/// Add a Custom Payment Service
+		/// </summary>
+		public PaymentService Create(PaymentService item)
+		{
+			return PaymentServices.Create(item);
+
+		}
+
+		/// <summary>
+		/// Add a Payment Service to a Branding Theme
+		/// </summary>
+		public void AddPaymentServiceToBrandingTheme(System.Guid brandingThemeId, System.Guid paymentServiceId)
+		{
+			PaymentServices.AddPaymentServiceToBrandingTheme(brandingThemeId, paymentServiceId);
+		}
+
+		#endregion
+
+		#region PurchaseOrders
 
         public IEnumerable<PurchaseOrder> Create(IEnumerable<PurchaseOrder> items)
         {

--- a/Xero.Api/Xero.Api.csproj
+++ b/Xero.Api/Xero.Api.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Core\Endpoints\Base\FourDecimalPlacesEndpoint.cs" />
     <Compile Include="Core\Endpoints\Base\IXeroCreateEndpoint.cs" />
     <Compile Include="Core\Endpoints\Base\IXeroUpdateEndpoint.cs" />
+    <Compile Include="Core\Endpoints\PaymentServicesEndpoint.cs" />
     <Compile Include="Core\Endpoints\BatchPaymentsEndpoint.cs" />
     <Compile Include="Core\Endpoints\ContactGroupEndpoint.cs" />
     <Compile Include="Core\Endpoints\FoldersEndpoint.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="Core\Endpoints\LinkedTransactionsEndpoint.cs" />
     <Compile Include="Core\Model\BatchPayment.cs" />
     <Compile Include="Core\Model\BatchPaymentPayment.cs" />
+    <Compile Include="Core\Model\PaymentService.cs" />
     <Compile Include="Core\Model\ContactCisSetting.cs" />
     <Compile Include="Core\Model\EnumExtensions.cs" />
     <Compile Include="Core\Model\HistoryRecord.cs" />
@@ -88,6 +90,7 @@
     <Compile Include="Core\Model\Types\OrganisationClass.cs" />
     <Compile Include="Core\Model\Types\OrganisationEdition.cs" />
     <Compile Include="Core\Model\Types\SourceType.cs" />
+    <Compile Include="Core\Request\PaymentServicesRequest.cs" />
     <Compile Include="Core\Request\BatchPaymentsRequest.cs" />
     <Compile Include="Core\Request\CurrenciesRequest.cs" />
     <Compile Include="Core\Request\HistoryRecordsRequest.cs" />
@@ -109,6 +112,7 @@
     <Compile Include="Core\Model\Types\OverpaymentType.cs" />
     <Compile Include="Common\CoreData.cs" />
     <Compile Include="Core\Model\Status\ValidationStatus.cs" />
+    <Compile Include="Core\Response\PaymentServicesResponse.cs" />
     <Compile Include="Core\Response\BatchPaymentsResponse.cs" />
     <Compile Include="Core\Response\ContactCisSettingsResponse.cs" />
     <Compile Include="Core\Response\HistoryRecordsResponse.cs" />


### PR DESCRIPTION
Hi,

I'm working on a partner integration that was started a year ago so its using the oauth1 connection stuff, but found out this sdk doesn't have anything for Payment Services. I did have a look at the NetStandard repo but with all the .net core changes and all the endpoints changed over to MethodName_Async_() it was going to be too much hassle to change over. (The project I'm using this with uses WCF services so doing async methods in that would have been a pain to change over).

So I've done a patch for creating Custom PaymentServices and adding a PaymentService to a Branding Theme. I've done a couple of example usage unit tests but they don't actually call the API due to it being a partner only feature.

Let me know what you think, not really expecting this to get merged in seeing as new apps should use auth2 connections now.

Luke

