### PR TITLE
Add `RequestHeaders` property to IAuthenticator, so the devs will be …

### DIFF
--- a/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
+++ b/Xero.Api.Example.Applications/Private/PrivateAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth;
@@ -47,5 +48,7 @@ namespace Xero.Api.Example.Applications.Private
         }
 
         public IUser User { get; set; }
+
+        public IEnumerable<KeyValuePair<string, string>> RequestHeaders { get; set; }
     }
 }

--- a/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
+++ b/Xero.Api.Example.Applications/TokenStoreAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xero.Api.Infrastructure.Interfaces;
 using Xero.Api.Infrastructure.OAuth;
 
@@ -74,6 +75,8 @@ namespace Xero.Api.Example.Applications
         }
 
         public IUser User { get; set; }
+
+        public IEnumerable<KeyValuePair<string, string>> RequestHeaders { get; set; }
 
         protected abstract string AuthorizeUser(IToken oauthToken);
         protected abstract string CreateSignature(IToken token, string verb, Uri uri, string verifier,

--- a/Xero.Api/Infrastructure/Http/HttpClient.cs
+++ b/Xero.Api/Infrastructure/Http/HttpClient.cs
@@ -184,6 +184,12 @@ namespace Xero.Api.Infrastructure.Http
                 var oauthSignature = _auth.GetSignature(Consumer, User, request.RequestUri, method, Consumer);
 
                 AddHeader("Authorization", oauthSignature);
+
+                if (_auth.RequestHeaders != null) {
+                    foreach (var header in _auth.RequestHeaders) {
+                        this.AddHeader(header.Key, header.Value);
+                    }
+                }
             }
             
             AddHeaders(request);

--- a/Xero.Api/Infrastructure/Interfaces/IAuthenticator.cs
+++ b/Xero.Api/Infrastructure/Interfaces/IAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Xero.Api.Infrastructure.Interfaces
 {
@@ -6,7 +7,7 @@ namespace Xero.Api.Infrastructure.Interfaces
     {
         string GetSignature(IConsumer consumer, IUser user, Uri uri, string verb, IConsumer consumer1);
         IToken GetToken(IConsumer consumer, IUser user);
-
+        IEnumerable<KeyValuePair<string, string>> RequestHeaders { get; set; }
         IUser User { get; set; }
     }
 }


### PR DESCRIPTION
Well, the dev document of xero says the old sdk will be still supported. But the fact is that there is no way to add an extra header to meet the need of `xero-tenant-id` when calling api. 

So this PR is try to solve this problem by adding a property `RequestHeaders ` into `IAuthenticator` header, and let http client to add headers before making the calls. 